### PR TITLE
Mark all errors during binds as failures in the result elements

### DIFF
--- a/src/lib/Server/Core.py
+++ b/src/lib/Server/Core.py
@@ -230,12 +230,14 @@ class Core(Component):
                 continue
             try:
                 self.Bind(entry, metadata)
-            except PluginExecutionError:
+            except PluginExecutionError, exc:
                 if 'failure' not in entry.attrib:
-                    entry.set('failure', 'bind error')
+                    entry.set('failure', 'bind error: %s' % exc)
                 logger.error("Failed to bind entry: %s %s" % \
                              (entry.tag, entry.get('name')))
-            except:
+            except Exception, exc:
+                if 'failure' not in entry.attrib:
+                    entry.set('failure', 'bind error: %s' % exc)
                 logger.error("Unexpected failure in BindStructure: %s %s" \
                              % (entry.tag, entry.get('name')), exc_info=1)
 


### PR DESCRIPTION
This will make the failed elements easier to track. (This is particularly a problem when exceptions get thrown from TGenshi templates, but I suspect it also affects other places)
