### PR TITLE
Teach bcfg2-info to use the filemonitor specified in the config file

### DIFF
--- a/src/sbin/bcfg2-info
+++ b/src/sbin/bcfg2-info
@@ -103,11 +103,11 @@ def displayTrace(trace, num=80, sort=('time', 'calls')):
 
 class infoCore(cmd.Cmd, Bcfg2.Server.Core.Core):
     """Main class for bcfg2-info."""
-    def __init__(self, repo, plgs, passwd, encoding, event_debug):
+    def __init__(self, repo, plgs, passwd, encoding, event_debug, filemonitor='default'):
         cmd.Cmd.__init__(self)
         try:
             Bcfg2.Server.Core.Core.__init__(self, repo, plgs, passwd,
-                                            encoding)
+                                            encoding, filemonitor)
             if event_debug:
                 self.fam.debug = True
         except Bcfg2.Server.Core.CoreInitError:
@@ -529,12 +529,12 @@ if __name__ == '__main__':
         prof = profile.Profile()
         loop = prof.runcall(infoCore, setup['repo'], setup['plugins'],
                             setup['password'], setup['encoding'],
-                            setup['event debug'])
+                            setup['event debug'], setup['filemonitor'])
         displayTrace(prof)
     else:
         if setup['profile']:
             print("Profiling functionality not available.")
         loop = infoCore(setup['repo'], setup['plugins'], setup['password'],
-                        setup['encoding'], setup['event debug'])
+                        setup['encoding'], setup['event debug'], setup['filemonitor'])
 
     loop.Run(setup['args'])


### PR DESCRIPTION
Currently, bcfg2-info doesn't use the filemonitor specified in the config file. This means that it's impossible to use the Pseudo monitor to ensure that all events are loaded before bcfg2-info finishes starting up.
