### PR TITLE
YUMng updates for master

### DIFF
--- a/src/lib/Client/Tools/YUMng.py
+++ b/src/lib/Client/Tools/YUMng.py
@@ -842,6 +842,16 @@ class YUMng(Bcfg2.Client.Tools.PkgTool):
             states[pkg] = self.VerifyPackage(pkg, [])
 
         # Install packages.
+        try:
+            # We want to reload all Yum configuration in case we've
+            # deployed new .repo files we should consider
+            self.yb = yum.YumBase()
+            self.yb.doTsSetup()
+            self.yb.doRpmDBSetup()
+            self.yb.doConfigSetup()
+        except Exception, e:
+            self.logger.warning("YUMng: Error Refreshing Yum Repos: %s" % e)
+
         if len(install_pkgs) > 0:
             self.logger.info("Attempting to install packages")
 


### PR DESCRIPTION
This fixes a condition where it would take two Bcfg2 runs to properly
deploy new packages.  Prior, if new specification deployed a new Yum
.repo file and new packages from that new repo, Bcfg2 would not be able
to install the new packages until the second run.  This change causes
Yum to reload all of its configuration and incorperate any new .repo
files before attempting to install packages.
