### PR TITLE
Fix how the filemonitor is passed in bcfg2-info

### DIFF
--- a/src/sbin/bcfg2-info
+++ b/src/sbin/bcfg2-info
@@ -107,7 +107,7 @@ class infoCore(cmd.Cmd, Bcfg2.Server.Core.Core):
         cmd.Cmd.__init__(self)
         try:
             Bcfg2.Server.Core.Core.__init__(self, repo, plgs, passwd,
-                                            encoding, filemonitor)
+                                            encoding, filemonitor=filemonitor)
             if event_debug:
                 self.fam.debug = True
         except Bcfg2.Server.Core.CoreInitError:


### PR DESCRIPTION
My last pull request had bug, and wasn't passing the filemonitor as the correct argument. This fixes that issue.
