### PR TITLE
openSUSE compat in spec file.

### DIFF
--- a/misc/bcfg2.spec
+++ b/misc/bcfg2.spec
@@ -10,11 +10,21 @@ Version:          1.2.1
 Release:          %{release}
 Summary:          Configuration management system
 
+%if 0%{?suse_version}
+# http://en.opensuse.org/openSUSE:Package_group_guidelines
+Group:            System/Management
+%else
 Group:            Applications/System
+%endif
 License:          BSD
 URL:              http://bcfg2.org
 Source0:          ftp://ftp.mcs.anl.gov/pub/bcfg/%{name}-%{version}.tar.gz
+%if 0%{?suse_version}
+# SUSEs OBS does not understand the id macro below.
+BuildRoot:        %{_tmppath}/%{name}-%{version}-%{release}
+%else
 BuildRoot:        %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+%endif
 
 BuildArch:        noarch
 
@@ -24,15 +34,16 @@ BuildRequires:    python-lxml
 # %{rhel} wasn't set before rhel 6.  so this checks for old RHEL
 # %systems (and potentially very old Fedora systems, too)
 %if "%{_vendor}" == "redhat" && 0%{?rhel} <= 6 && 0%{?fedora} == 0
-BuildRequires: python-sphinx10
+BuildRequires:    python-sphinx10
 # the python-sphinx10 package doesn't set sys.path correctly, so we
 # have to do it for them
 %define pythonpath /usr/lib/python%{py_ver}/site-packages/Sphinx-1.0.4-py%{py_ver}.egg
 %else
-BuildRequires: python-sphinx >= 0.6
+BuildRequires:    python-sphinx >= 0.6
 %endif
 
 Requires:         python-lxml >= 0.9
+Recommends:       cron
 
 %description
 Bcfg2 helps system administrators produce a consistent, reproducible,
@@ -60,17 +71,23 @@ systems are constantly changing; if required in your environment,
 Bcfg2 can enable the construction of complex change management and
 deployment strategies.
 
+This package includes the Bcfg2 client software.
+
 %package -n bcfg2-server
-Version: %{version}
-Summary: Bcfg2 Server
-Group: System Tools
-Requires: bcfg2
+Version:          %{version}
+Summary:          Bcfg2 Server
+%if 0%{?suse_version}
+Group:            System/Management
+%else
+Group:            System Tools
+%endif
+Requires:         bcfg2
 %if "%{py_ver}" < "2.6"
 Requires:         python-ssl
 %endif
 Requires:         python-lxml >= 1.2.1
 %if "%{_vendor}" == "redhat"
-Requires: gamin-python
+Requires:         gamin-python
 %endif
 
 %description -n bcfg2-server
@@ -99,24 +116,59 @@ systems are constantly changing; if required in your environment,
 Bcfg2 can enable the construction of complex change management and
 deployment strategies.
 
+This package includes the Bcfg2 server software.
+
 %package -n bcfg2-doc
 Summary:          Configuration management system documentation
+%if 0%{?suse_version}
+Group:            Documentation/HTML
+%else
 Group:            Documentation
+%endif
 
 %description -n bcfg2-doc
-Configuration management system documentation
+Bcfg2 helps system administrators produce a consistent, reproducible,
+and verifiable description of their environment, and offers
+visualization and reporting tools to aid in day-to-day administrative
+tasks. It is the fifth generation of configuration management tools
+developed in the Mathematics and Computer Science Division of Argonne
+National Laboratory.
+
+It is based on an operational model in which the specification can be
+used to validate and optionally change the state of clients, but in a
+feature unique to bcfg2 the client's response to the specification can
+also be used to assess the completeness of the specification. Using
+this feature, bcfg2 provides an objective measure of how good a job an
+administrator has done in specifying the configuration of client
+systems. Bcfg2 is therefore built to help administrators construct an
+accurate, comprehensive specification.
+
+Bcfg2 has been designed from the ground up to support gentle
+reconciliation between the specification and current client states. It
+is designed to gracefully cope with manual system modifications.
+
+Finally, due to the rapid pace of updates on modern networks, client
+systems are constantly changing; if required in your environment,
+Bcfg2 can enable the construction of complex change management and
+deployment strategies.
+
+This package includes the Bcfg2 documentation.
 
 %package -n bcfg2-web
-Version: %{version}
-Summary: Bcfg2 Web Reporting Interface
-Group: System Tools
-Requires: bcfg2-server
-Requires: httpd,Django
+Version:          %{version}
+Summary:          Bcfg2 Web Reporting Interface
+%if 0%{?suse_version}
+Group:            System/Management
+%else
+Group:            System Tools
+%endif
+Requires:         bcfg2-server
+Requires:         httpd,Django
 %if "%{_vendor}" == "redhat"
-Requires: mod_wsgi
+Requires:         mod_wsgi
 %define apache_conf %{_sysconfdir}/httpd
 %else
-Requires: apache2-mod_wsgi
+Requires:         apache2-mod_wsgi
 %define apache_conf %{_sysconfdir}/apache2
 %endif
 
@@ -146,6 +198,8 @@ systems are constantly changing; if required in your environment,
 Bcfg2 can enable the construction of complex change management and
 deployment strategies.
 
+This package includes the Bcfg2 reports web frontend.
+
 %prep
 %setup -q -n bcfg2-%{version}
 
@@ -166,6 +220,9 @@ deployment strategies.
 %{__install} -d %{buildroot}%{_sysconfdir}/cron.hourly
 %{__install} -d %{buildroot}%{_prefix}/lib/bcfg2
 mkdir -p %{buildroot}%{_defaultdocdir}/bcfg2-doc-%{version}
+%if 0%{?suse_version}
+%{__install} -d %{buildroot}/var/adm/fillup-templates
+%endif
 
 %{__mv} %{buildroot}/usr/bin/bcfg2* %{buildroot}%{_sbindir}
 %{__install} -m 755 debian/bcfg2.init %{buildroot}%{_initrddir}/bcfg2
@@ -175,6 +232,12 @@ mkdir -p %{buildroot}%{_defaultdocdir}/bcfg2-doc-%{version}
 %{__install} -m 755 debian/bcfg2.cron.daily %{buildroot}%{_sysconfdir}/cron.daily/bcfg2
 %{__install} -m 755 debian/bcfg2.cron.hourly %{buildroot}%{_sysconfdir}/cron.hourly/bcfg2
 %{__install} -m 755 tools/bcfg2-cron %{buildroot}%{_prefix}/lib/bcfg2/bcfg2-cron
+%if 0%{?suse_version}
+%{__install} -m 755 debian/bcfg2.default %{buildroot}/var/adm/fillup-templates/sysconfig.bcfg2
+%{__install} -m 755 debian/bcfg2-server.default %{buildroot}/var/adm/fillup-templates/sysconfig.bcfg2-server
+ln -s %{_initrddir}/bcfg2 %{buildroot}%{_sbindir}/rcbcfg2
+ln -s %{_initrddir}/bcfg2-server %{buildroot}%{_sbindir}/rcbcfg2-server
+%endif
 
 mv build/sphinx/html/* %{buildroot}%{_defaultdocdir}/bcfg2-doc-%{version}
 mv build/dtd %{buildroot}%{_defaultdocdir}/bcfg2-doc-%{version}/
@@ -190,7 +253,9 @@ mv build/dtd %{buildroot}%{_defaultdocdir}/bcfg2-doc-%{version}/
 %files -n bcfg2
 %defattr(-,root,root,-)
 %{_sbindir}/bcfg2
+%dir %{python_sitelib}/Bcfg2
 %{python_sitelib}/Bcfg2/*.py*
+%dir %{python_sitelib}/Bcfg2/Client
 %{python_sitelib}/Bcfg2/Client/*
 %{_mandir}/man1/bcfg2.1*
 %{_mandir}/man5/bcfg2.conf.5*
@@ -200,15 +265,56 @@ mv build/dtd %{buildroot}%{_defaultdocdir}/bcfg2-doc-%{version}/
 %{_sysconfdir}/cron.daily/bcfg2
 %{_prefix}/lib/bcfg2/bcfg2-cron
 %{_localstatedir}/cache/bcfg2
+%if 0%{?suse_version}
+%{_sbindir}/rcbcfg2
+%config(noreplace) /var/adm/fillup-templates/sysconfig.bcfg2
+%endif
+%ghost %attr(0600,root,root) %{_sysconfdir}/bcfg2.conf
 
 %post -n bcfg2-server
-/sbin/chkconfig --add bcfg2-server
+# enable daemon on first install only (not on update).
+if [ $1 -eq 1 ]; then
+%if 0%{?suse_version}
+  %fillup_and_insserv -f bcfg2-server
+%else
+  /sbin/chkconfig --add bcfg2-server
+%endif
+fi
+
+%preun -n bcfg2
+%if 0%{?suse_version}
+# stop on removal (not on update).
+if [ $1 -eq 0 ]; then
+  %stop_on_removal bcfg2
+fi
+%endif
+
+%preun -n bcfg2-server
+%if 0%{?suse_version}
+if [ $1 -eq 0 ]; then
+  %stop_on_removal bcfg2-server
+fi
+%endif
+
+%postun -n bcfg2
+%if 0%{?suse_version}
+if [ $1 -eq 0 ]; then
+  %insserv_cleanup
+fi
+%endif
+
+%postun -n bcfg2-server
+%if 0%{?suse_version}
+if [ $1 -eq 0 ]; then
+  # clean up on removal.
+  %insserv_cleanup
+fi
+%endif
 
 %files -n bcfg2-server
 %defattr(-,root,root,-)
-
 %{_initrddir}/bcfg2-server
-
+%dir %{python_sitelib}/Bcfg2
 %{python_sitelib}/Bcfg2/Server
 
 %if "%{pythonversion}" >= "2.5"
@@ -230,24 +336,34 @@ mv build/dtd %{buildroot}%{_defaultdocdir}/bcfg2-doc-%{version}/
 %{_sbindir}/bcfg2-server
 %{_sbindir}/bcfg2-yum-helper
 %{_sbindir}/bcfg2-test
+%if 0%{?suse_version}
+%{_sbindir}/rcbcfg2-server
+%config(noreplace) /var/adm/fillup-templates/sysconfig.bcfg2-server
+%endif
 
 %{_mandir}/man5/bcfg2-lint.conf.5*
 %{_mandir}/man8/*.8*
 %dir %{_prefix}/lib/bcfg2
+%ghost %attr(0600,root,root) %{_sysconfdir}/bcfg2.conf
 
-%files doc
+%files -n bcfg2-doc
 %defattr(-,root,root,-)
 %doc %{_defaultdocdir}/bcfg2-doc-%{version}
 
 %files -n bcfg2-web
 %defattr(-,root,root,-)
-
 %{_datadir}/bcfg2/reports.wsgi
 %{_datadir}/bcfg2/site_media
-
+%dir %{apache_conf}
+%dir %{apache_conf}/conf.d
 %config(noreplace) %{apache_conf}/conf.d/wsgi_bcfg2.conf
+%ghost %attr(0600,root,root) %{_sysconfdir}/bcfg2-web.conf
 
 %changelog
+* Tue Feb 14 2012 Christopher 'm4z' Holm <686f6c6d@googlemail.com> 1.2.1
+- Added openSUSE compatibility.
+- Various changes to satisfy rpmlint.
+
 * Thu Jan 27 2011 Chris St. Pierre <stpierreca@ornl.gov> 1.2.0pre1-0.0
 - Added -doc sub-package
 


### PR DESCRIPTION
As discussed on IRC, here's the openSUSE-compatible spec file.

Build results with this file are available here: https://build.opensuse.org/package/show?package=bcfg2-1.2.1&project=home%3Am4z%3Abcfg-dev (clicking on "succeeded" shows the build logs, including remaining warnings).

The reason it does not build on RHEL is that I don't know yet how/where to find the OBS project that contains python-sphinx10. (Similar problems exist for the other distros.)

It these are too many different changes in a commit (openSUSE additions, minor fixes like the %post section of bcfg2-server, changed %description of bcfg2-doc, whitespace changes all over the place), please throw them back at me and I'll request them separately.
