### PR TITLE
Adding DB2 support for Statistics

### DIFF
--- a/src/lib/Bcfg2/Server/Reports/settings.py
+++ b/src/lib/Bcfg2/Server/Reports/settings.py
@@ -43,6 +43,9 @@ DATABASES = {
     }
 }
 
+if db_engine == 'ibm_db_django':
+    DATABASES['default']['ENGINE'] = db_engine
+
 if db_engine != 'sqlite3':
     DATABASES['default']['USER'] =  c.get('statistics', 'database_user')
     DATABASES['default']['PASSWORD'] = c.get('statistics', 'database_password')


### PR DESCRIPTION
Adding DB2 support for Statistics, following guidance from
http://code.google.com/p/ibm-db/wiki/ibm_db_django_README
