### PR TITLE
The "extra_groups" attribute should be gone

### DIFF
--- a/tools/accounts2xml.py
+++ b/tools/accounts2xml.py
@@ -103,7 +103,6 @@ def main(args):
     item.setAttribute('name', gkey)
     (gid,extra) = gval.split(':')
     item.setAttribute('gid', gid)
-    item.setAttribute('extra_groups', extra)
 
   output_file = "accounts.xml"
   doc.writexml(open(output_file, 'w'), addindent='    ', newl='\n') # Write file


### PR DESCRIPTION
Hi,

The "extra_groups" attribute of <UnixGroup .. > tag should be removed because it is not recognized in accounts.genshi properly.

It did not fail to generate the accounts.xml file with the unnecessary attribute but it is better to clean it out.
