### PR TITLE
LDAP plugin: special characters in search filters need double escaping

### DIFF
--- a/src/lib/Bcfg2/Server/Plugins/Ldap.py
+++ b/src/lib/Bcfg2/Server/Plugins/Ldap.py
@@ -139,7 +139,7 @@ class LdapConnection(object):
                 result = self.conn.search_s(
                     query.base,
                     SCOPE_MAP[query.scope],
-                    query.filter,
+                    query.filter.replace("\\", "\\\\"),
                     query.attrs,
                 )
                 break


### PR DESCRIPTION
Example:

A search returns "cn=a+b" for some attribute containing a DN (such as "member").

When users try to create a search filter from that result, they should not need to mess around with escaping stuff and end up passing us this search filter: "(cn=a+b)".

That "+" is valid LDIF style escaping, but for our search to work, we need to escape the backslash by adding another, thus resulting in this filter being passed to python-ldap: "(cn=a\+b)"
