### PR TITLE
Chkconfig driver:  two fixes and RFE

### DIFF
--- a/src/lib/Bcfg2/Client/Tools/Chkconfig.py
+++ b/src/lib/Bcfg2/Client/Tools/Chkconfig.py
@@ -79,7 +79,7 @@ class Chkconfig(Bcfg2.Client.Tools.SvcTool):
             rv &= self.cmd.run(rcmd % (entry.get('name'),
                                        entry.get('status')))[0] == 0
             if entry.get("current_status") == "off":
-                rv &= self.start_service(entry)
+                rv &= (self.start_service(entry) == 0)
         return rv
 
     def FindExtra(self):


### PR DESCRIPTION
cd8d0b2 and 8402346 fix a couple of small bugs in chkconfig.

Fixed in another commit:
In interactive mode, 14f9753 joins the lines in a diff with '\n', just a tad easier to read than when joined with ''. ;)

Withdrawn:
90b5f73 adds a Service entry attribute 'ignore_current_status' to the Chkconfig driver, allowing broken init script status functions to be ignored.
