### PR TITLE
Fix daemonization issues with BuiltinCore

### DIFF
--- a/src/lib/Bcfg2/Server/BuiltinCore.py
+++ b/src/lib/Bcfg2/Server/BuiltinCore.py
@@ -20,9 +20,13 @@ class Core(BaseCore):
     name = 'bcfg2-server'
     
     def __init__(self, setup):
+        self.context = daemon.DaemonContext()
+        if setup['daemon']:
+            self.context.open()
+            open(setup['daemon'], "w").write("%s\n" % os.getpid())
+
         BaseCore.__init__(self, setup)
         self.server = None
-        self.context = daemon.DaemonContext()
 
     def _resolve_exposed_method(self, method_name):
         """Resolve an exposed method.
@@ -71,10 +75,6 @@ class Core(BaseCore):
             raise xmlrpclib.Fault(getattr(e, "fault_code", 1), str(e))
         return result
 
-    def _daemonize(self):
-        self.context.open()
-        self.logger.info("%s daemonized" % self.name)
-    
     def _run(self):
         hostname, port = urlparse(self.setup['location'])[1].split(':')
         server_address = socket.getaddrinfo(hostname,

--- a/src/lib/Bcfg2/Server/CherryPyCore.py
+++ b/src/lib/Bcfg2/Server/CherryPyCore.py
@@ -85,10 +85,11 @@ class Core(BaseCore):
         xmlrpcutil.respond(body, 'utf-8', True)
         return cherrypy.serving.response.body
 
-    def _daemonize(self):
-        Daemonizer(cherrypy.engine).subscribe()
-
     def _run(self):
+        if setup['daemon']:
+            Daemonizer(cherrypy.engine).subscribe()
+            self.logger.info("%s daemonized" % self.name)
+
         hostname, port = urlparse(self.setup['location'])[1].split(':')
         if self.setup['listen_all']:
             hostname = '0.0.0.0'

--- a/src/lib/Bcfg2/Server/Core.py
+++ b/src/lib/Bcfg2/Server/Core.py
@@ -475,9 +475,6 @@ class BaseCore(object):
     def run(self):
         """ run the server core. note that it is the responsibility of
         the server core implementation to call shutdown() """
-        if self.setup['daemon']:
-            self._daemonize()
-            open(self.setup['daemon'], "w").write("%s\n" % os.getpid())
 
         self._run()
 


### PR DESCRIPTION
When BuiltinCore daemonizes, the fam setup is destroyed, perhaps because
it has set up (although not run) threads.

This fix moves the _daemonize() code into the backends.  In the Builtin
backend, the core forks first thing in __init__().  In the
CherryPy backend, the core runs the cherrypy engine Daemonizer()
at the beginning of _run().
