### PR TITLE
Needed to specify the profile in the bcfg2.conf, added to Options.py

### DIFF
--- a/src/lib/Bcfg2/Options.py
+++ b/src/lib/Bcfg2/Options.py
@@ -585,7 +585,8 @@ CLIENT_PROFILE = \
     Option('Assert the given profile for the host',
            default=None,
            cmd='-p',
-           odesc='<profile>')
+           odesc='<profile>',
+           cf=('client', 'profile'))
 CLIENT_RETRIES = \
     Option('The number of times to retry network communication',
            default='3',


### PR DESCRIPTION
I couldn't tell if it was better to put it in 'client:profile' or 'communication:profile', but went with client as it seemed more obvious.

...g2.conf file. This is useful if you have a dynamic system and only the client has information on which profile to use.
