### PR TITLE
"AttributeError: 'Element' object has no attribute 'getparent'" if lxml is not installed

### DIFF
--- a/src/lib/Bcfg2/Client/Frame.py
+++ b/src/lib/Bcfg2/Client/Frame.py
@@ -228,12 +228,7 @@ class Frame(object):
 
         # take care of important entries first
         if not self.dryrun:
-            for cfile in self.config.findall(".//Path"):
-                if (cfile.get('name') not in self.__important__ or
-                    cfile.get('type') != 'file' or
-                    cfile not in self.whitelist):
-                    continue
-                parent = cfile.getparent()
+            for parent in self.config.findall(".//Path/.."):
                 if ((parent.tag == "Bundle" and
                      ((self.setup['bundle'] and
                        parent.get("name") not in self.setup['bundle']) or
@@ -242,9 +237,15 @@ class Frame(object):
                     (parent.tag == "Independent" and
                      (self.setup['bundle'] or self.setup['skipindep']))):
                     continue
-                tools = [t for t in self.tools
-                         if t.handlesEntry(cfile) and t.canVerify(cfile)]
-                if tools:
+                for cfile in parent.findall("./Path"):
+                    if (cfile.get('name') not in self.__important__ or
+                        cfile.get('type') != 'file' or
+                        cfile not in self.whitelist):
+                        continue
+                    tools = [t for t in self.tools
+                            if t.handlesEntry(cfile) and t.canVerify(cfile)]
+                    if not tools:
+                        continue
                     if (self.setup['interactive'] and not
                         self.promptFilter("Install %s: %s? (y/N):", [cfile])):
                         self.whitelist.remove(cfile)


### PR DESCRIPTION
Got this traceback upon running `bcfg2` on a fresh Precise install using the testing PPA (`bcfg2 1.3.0rc1 on Python 2.7.3`):

```
Traceback (most recent call last):
  File "/usr/sbin/bcfg2", line 29, in <module>
    sys.exit(main())
  File "/usr/sbin/bcfg2", line 26, in main
    return Client(setup).run()
  File "/usr/lib/pymodules/python2.7/Bcfg2/Client/Client.py", line 307, in run
    self.tools.Execute()
  File "/usr/lib/pymodules/python2.7/Bcfg2/Client/Frame.py", line 499, in Execute
    self.InstallImportant()
  File "/usr/lib/pymodules/python2.7/Bcfg2/Client/Frame.py", line 236, in InstallImportant
    parent = cfile.getparent()
AttributeError: 'Element' object has no attribute 'getparent'
```

Arises because of this check:

```
parent = cfile.getparent()
if ((parent.tag == "Bundle" and
     ((self.setup['bundle'] and
       parent.get("name") not in self.setup['bundle']) or
      (self.setup['skipbundle'] and
       parent.get("name") in self.setup['skipbundle']))) or
    (parent.tag == "Independent" and
     (self.setup['bundle'] or self.setup['skipindep']))):
    continue
```

However, `getparent()` only works if you have `lxml.etree` installed—`xml.etree` in the Python standard library (the fallback include) doesn't support this method.

Not confident enough in my understanding of what this code is doing to offer a patch, but hopefully it's a pretty straightforward fix.
