### PR TITLE
Systemd:  Fix server systemd unit

### DIFF
--- a/redhat/systemd/bcfg2-server.service
+++ b/redhat/systemd/bcfg2-server.service
@@ -7,8 +7,8 @@ Type=forking
 StandardOutput=syslog
 StandardError=syslog
 EnvironmentFile=-/etc/sysconfig/bcfg2-server
-PIDFile=/run/bcfg2-server.pid
-ExecStart=/usr/sbin/bcfg2-server -D /run/bcfg2-server.pid $BCFG2_SERVER_OPTIONS
+PIDFile=/run/bcfg2-server/bcfg2-server.pid
+ExecStart=/usr/sbin/bcfg2-server -D /run/bcfg2-server/bcfg2-server.pid $BCFG2_SERVER_OPTIONS
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- Run the daemon with -D /run/bcfg2-server.pid.  If you don't run it
  with -D PID, it doesn't fork, and since the unit file is
  Type=forking, the service eventually times out and fails.
- Use the PIDFile unit option to give systemd a hint where the PID
  file is located.  This is recommended when using Type=forking by the
  systemd documentation.
- Use $BCFG2_SERVER_OPTIONS, which is defined in
  /etc/sysconfig/bcfg2-server, instead of $OPTIONS, which is not.
