### PR TITLE
Added trailing / on MEDIA_URL to get rid of deprecated warnings

### DIFF
--- a/src/lib/Bcfg2/settings.py
+++ b/src/lib/Bcfg2/settings.py
@@ -106,7 +106,7 @@ def read_config(cfile=DEFAULT_CONFIG, repo=None, quiet=False):
     if setup['web_prefix']:
         MEDIA_URL = setup['web_prefix'].rstrip('/') + MEDIA_URL
     else:
-        MEDIA_URL = '/site_media'
+        MEDIA_URL = '/site_media/'
 
 # initialize settings from /etc/bcfg2-web.conf or /etc/bcfg2.conf, or
 # set up basic defaults.  this lets manage.py work in all cases


### PR DESCRIPTION
Sending the pull request as asked for by solj on IRC. Fixes Django deprecated warnings when starting bcfg2-server after upgrading from bcfg 1.2 to 1.3.

Best regards,

//Jon Norman
