### PR TITLE
Make the "latest" value more usable in VCS.py

### DIFF
--- a/src/lib/Bcfg2/Client/Tools/VCS.py
+++ b/src/lib/Bcfg2/Client/Tools/VCS.py
@@ -103,12 +103,19 @@ class VCS(Bcfg2.Client.Tools.Tool):
 
     def Verifysvn(self, entry, _):
         """Verify svn repositories"""
+        headrev = pysvn.Revision( pysvn.opt_revision_kind.head )
         client = pysvn.Client()
         try:
             cur_rev = str(client.info(entry.get('name')).revision.number)
+            server = client.info2(entry.get('sourceurl'), headrev, recurse=False)
+            if server:
+                server_rev = str(server[0][1].rev.number)
         except:
             self.logger.info("Repository %s does not exist" % entry.get('name'))
             return False
+
+        if entry.get('revision') == 'latest' and cur_rev == server_rev:
+            return True
 
         if cur_rev != entry.get('revision'):
             self.logger.info("At revision %s need to go to revision %s" %


### PR DESCRIPTION
Problem:
The current VCS.py file can not check if the working copy is already the latest version or not.
It always tries to run "svn up" even though it is already updated. So, it will cause the bcfg2 client side think that it always has incorrect entries. :-(

Solution:
Therefore, I tired make the "latest" value of the "revision" attribute update the working copy only when the working copy is not updated to the latest revision.
