### PR TITLE
Pass through retval from start, stop, status, etc. in init scripts

### DIFF
--- a/debian/bcfg2-report-collector.init
+++ b/debian/bcfg2-report-collector.init
@@ -32,6 +32,7 @@ test -x $DAEMON || exit 5
 
 # Internal variables
 BINARY=$(basename $DAEMON)
+RETVAL=0
 
 start () {
     echo -n "Starting Configuration Report Collector: "
@@ -85,22 +86,26 @@ status () {
 case "$1" in
     start)
         start
+        RETVAL=$?
     ;;
     stop)
         stop
+        RETVAL=$?
     ;;
     status)
         status
+        RETVAL=$?
     ;;
     restart|reload|force-reload)
         stop
         sleep 5
         start
+        RETVAL=$?
     ;;
     *)
         log_success_msg "Usage: $0 {start|stop|status|reload|restart|force-reload}"
-        exit 1
+        RETVAL=1
     ;;
 esac
 
-exit 0
+exit $RETVAL

--- a/debian/bcfg2-server.init
+++ b/debian/bcfg2-server.init
@@ -41,6 +41,7 @@ test -x $DAEMON || exit 5
 
 # Internal variables
 BINARY=$(basename $DAEMON)
+RETVAL=0
 
 start () {
     echo -n "Starting Configuration Management Server: "
@@ -91,22 +92,26 @@ status () {
 case "$1" in
     start)
         start
+        RETVAL=$?
     ;;
     stop)
         stop
+        RETVAL=$?
     ;;
     status)
         status
+        RETVAL=$?
     ;;
     restart|reload|force-reload)
         stop
         sleep 5
         start
+        RETVAL=$?
     ;;
     *)
         log_success_msg "Usage: $0 {start|stop|status|reload|restart|force-reload}"
-        exit 1
+        RETVAL=1
     ;;
 esac
 
-exit 0
+exit $RETVAL

--- a/debian/bcfg2.init
+++ b/debian/bcfg2.init
@@ -47,6 +47,7 @@ fi
 
 # Internal variables
 BINARY=$(basename $BCFG2)
+RETVAL=0
 
 # Include lsb functions
 . /lib/lsb/init-functions
@@ -70,17 +71,19 @@ start () {
 case "$1" in
     start)
         start
+        RETVAL=$?
         ;;
     stop|status)
-        exit 0
+        RETVAL=0
         ;;
     restart|force-reload)
 	start
+        RETVAL=$?
         ;;
     *)
         echo "Usage: $0 {start|stop|status|restart|force-reload}"
-        exit 1
+        RETVAL=1
         ;;
 esac
 
-exit 0
+exit $RETVAL

--- a/redhat/scripts/bcfg2-report-collector.init
+++ b/redhat/scripts/bcfg2-report-collector.init
@@ -32,6 +32,7 @@ test -x $DAEMON || exit 5
 
 # Internal variables
 BINARY=$(basename $DAEMON)
+RETVAL=0
 
 start () {
     echo -n "Starting Configuration Report Collector: "
@@ -79,22 +80,26 @@ status () {
 case "$1" in
     start)
         start
+        RETVAL=$?
     ;;
     stop)
         stop
+        RETVAL=$?
     ;;
     status)
         status
+        RETVAL=$?
     ;;
     restart|reload|force-reload)
         stop
         sleep 5
         start
+        RETVAL=$?
     ;;
     *)
         echo "Usage: $0 {start|stop|status|reload|restart|force-reload}"
-        exit 1
+        RETVAL=1
     ;;
 esac
 
-exit 0
+exit $RETVAL

--- a/redhat/scripts/bcfg2-server.init
+++ b/redhat/scripts/bcfg2-server.init
@@ -59,9 +59,11 @@ stop () {
 case "$1" in
     start)
         start
+        RETVAL=$?
     ;;
     stop)
         stop
+        RETVAL=$?
     ;;
     status)
         status $prog
@@ -71,6 +73,7 @@ case "$1" in
         stop
         sleep 5
         start
+        RETVAL=$?
     ;;
     *)
         echo $"Usage: $0 {start|stop|status|restart|reload|force-reload}"

--- a/redhat/scripts/bcfg2.init
+++ b/redhat/scripts/bcfg2.init
@@ -54,12 +54,14 @@ start () {
 case "$1" in
     start)
         start
+        RETVAL=$?
         ;;
     stop|status)
-        exit 0
+        RETVAL=0
         ;;
     restart|force-reload)
 	start
+        RETVAL=$?
         ;;
     *)
         echo "Usage: $0 {start|stop|status|restart|force-reload}"


### PR DESCRIPTION
The various init scripts have the usual start, stop, and status
functions which are called from a case statement.  The functions
even nicely return various values for success and failure.
Unfortunately, those values were not passed all the way back to the
calling shell.

Previously, the init scripts would return 0 if any of start, stop, or
status failed.  This commit ensures that they they pass the return
value back to the caller.

Why does this matter?  Well, beyond just being generally good
citizens, bcfg2's own chkconfig client tool expects stopped services
to return a non-zero exit code when their status function is called.
Otherwise it flags the service state as incorrect and tries to stop
it on every run.
