### PR TITLE
Update bcfg2-info OptionParser to use client options

### DIFF
--- a/src/lib/Bcfg2/Options.py
+++ b/src/lib/Bcfg2/Options.py
@@ -1269,6 +1269,10 @@ TEST_COMMON_OPTIONS = dict(noseopts=TEST_NOSEOPTS,
                            xunit=TEST_XUNIT,
                            validate=CFG_VALIDATION)
 
+INFO_COMMON_OPTIONS = dict(ppath=PARANOID_PATH,
+                           max_copies=PARANOID_MAX_COPIES)
+INFO_COMMON_OPTIONS.update(CLI_COMMON_OPTIONS)
+INFO_COMMON_OPTIONS.update(SERVER_COMMON_OPTIONS)
 
 class OptionParser(OptionSet):
     """

--- a/src/sbin/bcfg2-info
+++ b/src/sbin/bcfg2-info
@@ -754,8 +754,7 @@ def main():
     optinfo = dict(profile=Bcfg2.Options.CORE_PROFILE,
                    interactive=Bcfg2.Options.INTERACTIVE,
                    interpreter=Bcfg2.Options.INTERPRETER)
-    optinfo.update(Bcfg2.Options.CLI_COMMON_OPTIONS)
-    optinfo.update(Bcfg2.Options.SERVER_COMMON_OPTIONS)
+    optinfo.update(Bcfg2.Options.INFO_COMMON_OPTIONS)
     setup = Bcfg2.Options.OptionParser(optinfo)
     setup.hm = "\n".join(["     bcfg2-info [options] [command <command args>]",
                           "Options:",


### PR DESCRIPTION
bcfg2-info uses CLI_COMMON_OPTIONS which is a subset of the
full CLIENT_COMMON_OPTIONS that the bcfg2 client uses.  This causes
bcfg2-info to fail on the builddir comand with the following traceback

> builddir drdws0056.nyc.desres.deshaw.com /tmp/drdws0056
> Command failure
> Traceback (most recent call last):
>   File "/usr/sbin/bcfg2-info", line 157, in do_loop
>     self.cmdloop('Welcome to bcfg2-info\n'
>   File "/usr/lib64/python2.4/cmd.py", line 142, in cmdloop
>     stop = self.onecmd(line)
>   File "/usr/lib64/python2.4/cmd.py", line 219, in onecmd
>     return func(arg)
>   File "/usr/sbin/bcfg2-info", line 283, in do_builddir
>     client_config)
>   File "/usr/lib/python2.4/site-packages/Bcfg2/Client/Tools/POSIX/**init**.py", line 19, in **init**
>     self.ppath = setup['ppath']
> KeyError: 'ppath'

ppath is included in CLIENT_COMMON_OPTIONS, but not CLI_COMMON_OPTIONS
so this commit changes bcfg2-info to parse the fuller
CLIENT_COMMON_OPTIONS.
