### PR TITLE
make chkconfig tool driver respect servicemode

### DIFF
--- a/src/lib/Bcfg2/Client/Tools/Chkconfig.py
+++ b/src/lib/Bcfg2/Client/Tools/Chkconfig.py
@@ -65,16 +65,18 @@ class Chkconfig(Bcfg2.Client.Tools.SvcTool):
         self.cmd.run("/sbin/chkconfig --add %s" % (entry.attrib['name']))
         self.logger.info("Installing Service %s" % (entry.get('name')))
         rv = True
-        if entry.get('status') == 'off':
+        if entry.get('status') == 'off' or self.setup["servicemode"] == "build":
             rv &= self.cmd.run((rcmd + " --level 0123456") %
                                (entry.get('name'),
                                 entry.get('status'))).success
-            if entry.get("current_status") == "on":
+            if entry.get("current_status") == "on" and \
+               self.setup["servicemode"] != "disabled":
                 rv &= self.stop_service(entry).success
         else:
             rv &= self.cmd.run(rcmd % (entry.get('name'),
                                        entry.get('status'))).success
-            if entry.get("current_status") == "off":
+            if entry.get("current_status") == "off" and \
+               self.setup["servicemode"] != "disabled":
                 rv &= self.start_service(entry).success
         return rv
 


### PR DESCRIPTION
The bcfg2 man page states that -s disabled should stop bcfg2 from
attempting to modify any services, but the Chkconfig driver (at least)
does start the service during the Install phase even with -s disabled.
This patch adds support to the Chkconfig driver for the servicemode
config parameter.  It still does chkconfig --add, which I think makes
sense to happen as part of configuration, but it does not attempt
to actually start the service.
