### PR TITLE
client POSIX directory tool:  fix removal of extra 'entries'

### DIFF
--- a/src/lib/Bcfg2/Client/Tools/POSIX/Directory.py
+++ b/src/lib/Bcfg2/Client/Tools/POSIX/Directory.py
@@ -36,14 +36,14 @@ class POSIXDirectory(POSIXTool):
                     self.logger.info("POSIX: " + msg)
                     entry.set('qtext', entry.get('qtext', '') + '\n' + msg)
                     for extra in extras:
-                        Bcfg2.Client.XML.SubElement(entry, 'Prune', path=extra)
+                        Bcfg2.Client.XML.SubElement(entry, 'Prune', name=extra)
             except OSError:
                 prune = True
 
         return POSIXTool.verify(self, entry, modlist) and prune
 
     def install(self, entry):
-        """Install device entries."""
+        """Remove extra entries in a directory."""
         fmode = self._exists(entry)
 
         if fmode and not stat.S_ISDIR(fmode[stat.ST_MODE]):


### PR DESCRIPTION
POSIXTool._remove() expects an entry with a path in the 'name'
attribute

Fix the install() method docstring
