### PR TITLE
Schema: Removing "required" from some Action attributes

### DIFF
--- a/schemas/types.xsd
+++ b/schemas/types.xsd
@@ -119,14 +119,14 @@
       </xsd:documentation>
     </xsd:annotation>
 
-    <xsd:attribute type='ActionTimingEnum' name='timing' use='required'>
+    <xsd:attribute type='ActionTimingEnum' name='timing'>
       <xsd:annotation>
         <xsd:documentation>
           When the action is run.
         </xsd:documentation>
       </xsd:annotation>
     </xsd:attribute>
-    <xsd:attribute type='ActionWhenEnum' name='when' use='required'>
+    <xsd:attribute type='ActionWhenEnum' name='when'>
       <xsd:annotation>
         <xsd:documentation>
           If the action is always run, or is only run when a bundle
@@ -136,7 +136,7 @@
         </xsd:documentation>
       </xsd:annotation>
     </xsd:attribute>
-    <xsd:attribute type='ActionStatusEnum' name='status' use='required'>
+    <xsd:attribute type='ActionStatusEnum' name='status'>
       <xsd:annotation>
         <xsd:documentation>
           Whether or not to check the return code of the action.  If


### PR DESCRIPTION
These attributes being required breaks bcfg2-lint when the required attributes are specified by another plugin by Defaults.

Long term fix would be to fully bind the entries before running them through lint but this fixes it for now.
