### PR TITLE
Client/Tools/Action: add shell attribute

### DIFF
--- a/schemas/types.xsd
+++ b/schemas/types.xsd
@@ -162,8 +162,16 @@
     <xsd:attribute type='xsd:string' name='command' use='required'>
       <xsd:annotation>
         <xsd:documentation>
-          The command to run.  The command is executed within a shell,
-          so flow control and other shell-specific things can be used.
+          The command to run.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute type='xsd:boolean' name='shell'>
+      <xsd:annotation>
+        <xsd:documentation>
+          Whether the command string should be executeed within a shell.
+          If enabled flow control and other shell-specific things can
+          be used.
         </xsd:documentation>
       </xsd:annotation>
     </xsd:attribute>

--- a/src/lib/Bcfg2/Client/Tools/Action.py
+++ b/src/lib/Bcfg2/Client/Tools/Action.py
@@ -32,10 +32,17 @@ class Action(Bcfg2.Client.Tools.Tool):
 
     def RunAction(self, entry):
         """This method handles command execution and status return."""
+        shell = False
+        shell_string = ''
+        if entry.get('shell', 'false') == 'true':
+            shell = True
+            shell_string = '(in shell) '
+
         if not self.setup['dryrun']:
             if self.setup['interactive']:
-                prompt = ('Run Action %s, %s: (y/N): ' %
-                          (entry.get('name'), entry.get('command')))
+                prompt = ('Run Action %s%s, %s: (y/N): ' %
+                          (shell_string, entry.get('name'),
+                           entry.get('command')))
                 # flush input buffer
                 while len(select.select([sys.stdin.fileno()], [], [],
                                         0.0)[0]) > 0:
@@ -48,8 +55,9 @@ class Action(Bcfg2.Client.Tools.Tool):
                     self.logger.debug("Action: Deferring execution of %s due "
                                       "to build mode" % entry.get('command'))
                     return False
-            self.logger.debug("Running Action %s" % (entry.get('name')))
-            rv = self.cmd.run(entry.get('command'))
+            self.logger.debug("Running Action %s %s" %
+                              (shell_string, entry.get('name')))
+            rv = self.cmd.run(entry.get('command'), shell=shell)
             self.logger.debug("Action: %s got return code %s" %
                               (entry.get('command'), rv.retval))
             entry.set('rc', str(rv.retval))


### PR DESCRIPTION
Add an option to specify whether a command should be executed within
a shell to enable flow control and other shell-specific syntax. The behavior
of 1.3.1 before had changed from 1.2.x. It was documented that the Action
always is executed within a shell. But the restructuring with
Bcfg2.Utils.Executor change the default mode to execute all Actions without
a shell. This patch adds an option, so that everyone could specify the default
mode with the Rules or per Action.
