### PR TITLE
fix TCheetah documentation

### DIFF
--- a/doc/server/plugins/generators/tcheetah.txt
+++ b/doc/server/plugins/generators/tcheetah.txt
@@ -99,7 +99,7 @@ Simple Example
 ==============
 
 TCheetah works similar to Cfg in that you define all literal information
-about a particular file in a directory rooted at TGenshi/path_to_file.
+about a particular file in a directory rooted at TCheetah/path_to_file.
 The actual file contents are placed in a file named `template` in that
 directory. Below is a simple example a file ``/foo``.
 


### PR DESCRIPTION
The TCheetah documentation contains a reference to TGenshi. It was maybe a
left over from generating the TCheetah docs from the TGenshi docs.
