### PR TITLE
Server/Admin/Syncdb: add missing import

### DIFF
--- a/src/lib/Bcfg2/Server/Admin/Syncdb.py
+++ b/src/lib/Bcfg2/Server/Admin/Syncdb.py
@@ -3,6 +3,7 @@ import Bcfg2.settings
 import Bcfg2.Options
 import Bcfg2.Server.Admin
 import Bcfg2.Server.models
+from django.core.exceptions import ImproperlyConfigured
 from django.core.management import setup_environ, call_command
 
 


### PR DESCRIPTION
The import for ImproperlyConfigured was missing.
