### PR TITLE
Client/Tools/VCS: fix symlink handling

### DIFF
--- a/src/lib/Bcfg2/Client/Tools/VCS.py
+++ b/src/lib/Bcfg2/Client/Tools/VCS.py
@@ -136,7 +136,7 @@ class VCS(Bcfg2.Client.Tools.Tool):
             full_path = os.path.join(destname, fname)
             dulwich.file.ensure_dir_exists(os.path.dirname(full_path))
 
-            if dulwich.objects.S_ISGITLINK(mode):
+            if stat.S_ISLNK(mode):
                 src_path = destr[sha].as_raw_string()
                 try:
                     os.symlink(src_path, full_path)


### PR DESCRIPTION
dulwich.objects.S_ISGITLINK returns True if the given entry is a git-submodule NOT if it's a symlink. So this commit fixes the symlink handling.
