### PR TITLE
Django db options

### DIFF
--- a/doc/man/bcfg2.conf.txt
+++ b/doc/man/bcfg2.conf.txt
@@ -729,6 +729,11 @@ control the database connection of the server.
     port
         Port for database connections. Not used for sqlite3.
 
+    options
+        Various options for the database connection. The value is
+        expected as multiple key=value pairs, separated with commas.
+        The concrete value depends on the database engine.
+
 Reporting options
 -----------------
 

--- a/doc/server/database.txt
+++ b/doc/server/database.txt
@@ -49,6 +49,12 @@ of ``/etc/bcfg2.conf``.
 +-------------+------------------------------------------------------------+-------------------------------+
 | port        | The port to connect to                                     | None                          |
 +-------------+------------------------------------------------------------+-------------------------------+
+| options     | Extra parameters to use when connecting to the database.   | None                          |
+|             | Available parameters vary depending on your database       |                               |
+|             | backend. The parameters are supplied as comma separated    |                               |
+|             | key=value pairs.                                           |                               |
++-------------+------------------------------------------------------------+-------------------------------+
+
 
 Database Schema Sync
 ====================

--- a/man/bcfg2.conf.5
+++ b/man/bcfg2.conf.5
@@ -1,4 +1,4 @@
-.TH "BCFG2.CONF" "5" "March 18, 2013" "1.3" "Bcfg2"
+.TH "BCFG2.CONF" "5" "June 19, 2013" "1.3" "Bcfg2"
 .SH NAME
 bcfg2.conf \- Configuration parameters for Bcfg2
 .
@@ -771,6 +771,11 @@ Host for database connections. Not used for sqlite3.
 .TP
 .B port
 Port for database connections. Not used for sqlite3.
+.TP
+.B options
+Various options for the database connection. The value is
+expected as multiple key=value pairs, separated with commas.
+The concrete value depends on the database engine.
 .UNINDENT
 .UNINDENT
 .UNINDENT

--- a/src/lib/Bcfg2/Options.py
+++ b/src/lib/Bcfg2/Options.py
@@ -674,6 +674,12 @@ DB_PORT = \
            cf=('database', 'port'),
            deprecated_cf=('statistics', 'database_port'))
 
+DB_OPTIONS = \
+    Option('Database options',
+           default=dict(),
+           cf=('database', 'options'),
+           cook=dict_split)
+
 # Django options
 WEB_CFILE = \
     Option('Web interface configuration file',
@@ -1307,6 +1313,7 @@ DATABASE_COMMON_OPTIONS = dict(web_configfile=WEB_CFILE,
                                db_password=DB_PASSWORD,
                                db_host=DB_HOST,
                                db_port=DB_PORT,
+                               db_options=DB_OPTIONS,
                                time_zone=DJANGO_TIME_ZONE,
                                django_debug=DJANGO_DEBUG,
                                web_prefix=DJANGO_WEB_PREFIX)

--- a/src/lib/Bcfg2/settings.py
+++ b/src/lib/Bcfg2/settings.py
@@ -26,6 +26,7 @@ DATABASE_USER = None
 DATABASE_PASSWORD = None
 DATABASE_HOST = None
 DATABASE_PORT = None
+DATABASE_OPTIONS = None
 
 TIME_ZONE = None
 
@@ -58,8 +59,8 @@ def read_config(cfile=DEFAULT_CONFIG, repo=None, quiet=False):
     """ read the config file and set django settings based on it """
     # pylint: disable=W0602,W0603
     global DATABASE_ENGINE, DATABASE_NAME, DATABASE_USER, DATABASE_PASSWORD, \
-        DATABASE_HOST, DATABASE_PORT, DEBUG, TEMPLATE_DEBUG, TIME_ZONE, \
-        MEDIA_URL
+        DATABASE_HOST, DATABASE_PORT, DATABASE_OPTIONS, DEBUG, \
+        TEMPLATE_DEBUG, TIME_ZONE, MEDIA_URL
     # pylint: enable=W0602,W0603
 
     if not os.path.exists(cfile) and os.path.exists(DEFAULT_CONFIG):
@@ -86,7 +87,8 @@ def read_config(cfile=DEFAULT_CONFIG, repo=None, quiet=False):
              USER=setup['db_user'],
              PASSWORD=setup['db_password'],
              HOST=setup['db_host'],
-             PORT=setup['db_port'])
+             PORT=setup['db_port'],
+             OPTIONS=setup['db_options'])
 
     if HAS_DJANGO and django.VERSION[0] == 1 and django.VERSION[1] < 2:
         DATABASE_ENGINE = setup['db_engine']
@@ -95,6 +97,7 @@ def read_config(cfile=DEFAULT_CONFIG, repo=None, quiet=False):
         DATABASE_PASSWORD = DATABASES['default']['PASSWORD']
         DATABASE_HOST = DATABASES['default']['HOST']
         DATABASE_PORT = DATABASES['default']['PORT']
+        DATABASE_OPTIONS = DATABASES['default']['OPTIONS']
 
     # dropping the version check.  This was added in 1.1.2
     TIME_ZONE = setup['time_zone']


### PR DESCRIPTION
The config currently does not have a possibility to set the database options for django. With this patch it is possible to set something like:

```
[database]
options = sslmode=require
```

to force the use of ssl for postgres connections.
