### PR TITLE
Plugins/Metadata: fix resolution for ipv4-in-ipv6 addresses like ::ffff:127.0.0.1

### DIFF
--- a/src/lib/Bcfg2/Server/Plugins/Metadata.py
+++ b/src/lib/Bcfg2/Server/Plugins/Metadata.py
@@ -1055,7 +1055,7 @@ class Metadata(Bcfg2.Server.Plugin.Metadata,
                 raise Bcfg2.Server.Plugin.MetadataConsistencyError(err)
             return self.addresses[address][0]
         try:
-            cname = socket.gethostbyaddr(address)[0].lower()
+            cname = socket.getnameinfo(addresspair, socket.NI_NAMEREQD)[0].lower()
             if cname in self.aliases:
                 return self.aliases[cname]
             return cname


### PR DESCRIPTION
Hi,

while connecting with an old client (bcfg2-1.2.3) to an new server (bcfg2-1.3.1+) I noticed that the special form for embedding an IPv4 address into the IPv6 address space (like ::ffff:130.133.110.115) could not be resolved by gethostbyaddr leading to this backtrace:

```
Unexpected Authentication Failure
Traceback (most recent call last):
  File "/usr/lib/python2.6/dist-packages/Bcfg2/SSLServer.py", line 221, in parse_request
    if not self.authenticate():
  File "/usr/lib/python2.6/dist-packages/Bcfg2/SSLServer.py", line 211, in authenticate
   password, client_address)
 File "/usr/lib/python2.6/dist-packages/Bcfg2/Server/Core.py", line 1164, in authenticate
   address)
 File "/usr/lib/python2.6/dist-packages/Bcfg2/Server/Plugins/Metadata.py", line 1313, in AuthenticateConnection
   client = self.resolve_client(address)
 File "/usr/lib/python2.6/dist-packages/Bcfg2/Server/Plugins/Metadata.py", line 1058, in resolve_client
   cname = socket.gethostbyaddr(address)[0].lower()
error: Address family not supported by protocol
::ffff:130.133.110.115 - - [27/Jun/2013 17:34:38] code 401, message Unauthorized
```

This is fixed with this little patch.
