### PR TITLE
remove python-lxml dependency (python <2.7 compatibility)

### DIFF
--- a/src/lib/Bcfg2/Client/Frame.py
+++ b/src/lib/Bcfg2/Client/Frame.py
@@ -207,12 +207,15 @@ class Frame(object):
 
         # take care of important entries first
         if not self.dryrun:
+            parent_map = dict((c, p)
+                              for p in self.config.getiterator()
+                              for c in p)
             for cfile in self.config.findall(".//Path"):
                 if (cfile.get('name') not in self.__important__ or
                     cfile.get('type') != 'file' or
                     cfile not in self.whitelist):
                     continue
-                parent = cfile.getparent()
+                parent = parent_map[cfile]
                 if ((parent.tag == "Bundle" and
                      ((self.setup['bundle'] and
                        parent.get("name") not in self.setup['bundle']) or


### PR DESCRIPTION
The previous solution to avoid the python-lxml dependency does only work on python2.7 or newer. Before that version xml.etree does not support ".." in xpath expressions. So the findall(".//Path/..") fails. This patch fix this by manually building a parent map and using this to get the parent of the <Path> elements.
