### PR TITLE
Executor: do not split the command line if shell is true

### DIFF
--- a/src/lib/Bcfg2/Utils.py
+++ b/src/lib/Bcfg2/Utils.py
@@ -216,7 +216,9 @@ class Executor(object):
         """
         if isinstance(command, str):
             cmdstr = command
-            command = shlex.split(cmdstr)
+
+            if not shell:
+                command = shlex.split(cmdstr)
         else:
             cmdstr = " ".join(command)
         self.logger.debug("Running: %s" % cmdstr)


### PR DESCRIPTION
If the command should be excuted within a shell, it should not be
splited into a list. If subcommand.Popen gets a list, the first element
is the command and all other are the arguements. This breaks the shell
evaluation of the commamnd.
