### PR TITLE
bcfg2-reports: update to use current models

### DIFF
--- a/src/sbin/bcfg2-reports
+++ b/src/sbin/bcfg2-reports
@@ -53,15 +53,15 @@ def print_fields(fields, client, fmt, extra=None):
             else:
                 fdata.append("dirty")
         elif field == 'total':
-            fdata.append(client.current_interaction.totalcount)
+            fdata.append(client.current_interaction.total_count)
         elif field == 'good':
-            fdata.append(client.current_interaction.goodcount)
+            fdata.append(client.current_interaction.good_count)
         elif field == 'modified':
-            fdata.append(client.current_interaction.modified_entry_count())
+            fdata.append(client.current_interaction.modified_count)
         elif field == 'extra':
-            fdata.append(client.current_interaction.extra_entry_count())
+            fdata.append(client.current_interaction.extra_count)
         elif field == 'bad':
-            fdata.append((client.current_interaction.badcount()))
+            fdata.append(client.current_interaction.bad_count)
         else:
             try:
                 fdata.append(getattr(client, field))


### PR DESCRIPTION
modified_entry_count() and extra_entry_count() is not available anymore so we have to change it. The other changes are made to unify the model usage.

By the way: Is there any reason there is a badcount() and bad_count in the Interaction model? Especially badcount() does not use the bad_count field available but instead calculates the value via total_count - good_count. Additional to that percentbad also does not use the bad_count field but isclean() uses the bad_count property.
