### PR TITLE
Chkconfig: give --list option to chkconfig rather than sending it on stdin

### DIFF
--- a/src/lib/Bcfg2/Client/Tools/Chkconfig.py
+++ b/src/lib/Bcfg2/Client/Tools/Chkconfig.py
@@ -116,8 +116,8 @@ class Chkconfig(Bcfg2.Client.Tools.SvcTool):
     def FindExtra(self):
         """Locate extra chkconfig Services."""
         allsrv = [line.split()[0]
-                  for line in self.cmd.run("/sbin/chkconfig",
-                                           "--list").stdout.splitlines()
+                  for line in
+                  self.cmd.run("/sbin/chkconfig --list").stdout.splitlines()
                   if ":on" in line]
         self.logger.debug('Found active services:')
         self.logger.debug(allsrv)


### PR DESCRIPTION
The Chkconfig tool driver calls 

self.cmd.run("/sbin/chkconfig", "--list") 

rather than 

self.cmd.run("/sbin/chkconfig --list")

This results in chkconfig printing its usage info rather than providing a list of services.
