### PR TITLE
Chkconfig should not set service to "on" on every run level

### DIFF
--- a/src/lib/Bcfg2/Client/Tools/Chkconfig.py
+++ b/src/lib/Bcfg2/Client/Tools/Chkconfig.py
@@ -89,7 +89,7 @@ class Chkconfig(Bcfg2.Client.Tools.SvcTool):
         if bootstatus is not None:
             if bootstatus == 'on':
                 # make sure service is enabled on boot
-                bootcmd = '/sbin/chkconfig %s %s --level 0123456' % \
+                bootcmd = '/sbin/chkconfig %s %s' % \
                           (entry.get('name'), bootstatus)
             elif bootstatus == 'off':
                 # make sure service is disabled on boot


### PR DESCRIPTION
Let chkconfig assign default runlevels. 
