### PR TITLE
Replace use of gethostbyname by getaddrinfo

### DIFF
--- a/src/lib/Bcfg2/Server/Plugins/NagiosGen.py
+++ b/src/lib/Bcfg2/Server/Plugins/NagiosGen.py
@@ -39,8 +39,8 @@ class NagiosGen(Plugin, Generator):
     def createhostconfig(self, entry, metadata):
         """Build host specific configuration file."""
         try:
-            host_address = socket.gethostbyname(metadata.hostname)
-        except socket.gaierror:
+            host_address = socket.getaddrinfo(metadata.hostname, None)[0][4][0]
+        except socket.error:
             self.logger.error()
             raise PluginExecutionError("Failed to find IP address for %s" %
                                        metadata.hostname)


### PR DESCRIPTION
This replaces the remaining gethostbyname() call by the equivalent
getaddrinfo() call required to properly cope with hosts being only
reachable over IPv6.
