### PR TITLE
Don't crash when a file diff contains utf-8 chars

### DIFF
--- a/src/lib/Bcfg2/Client/__init__.py
+++ b/src/lib/Bcfg2/Client/__init__.py
@@ -21,6 +21,9 @@ def prompt(msg):
     try:
         ans = input(msg)
         return ans in ['y', 'Y']
+    except UnicodeEncodeError:
+        ans = input(msg.encode('utf-8'))
+        return ans in ['y', 'Y']
     except EOFError:
         # handle ^C on rhel-based platforms
         raise SystemExit(1)


### PR DESCRIPTION
This fixes a crash when the client tries to render the diff of a file
which includes unicode characters. This change assumes that utf-8 is the
default encoding, which looking at the rest of the code appears to be a
safe bet.

Signed-off-by: Stéphane Graber stgraber@ubuntu.com
