### PR TITLE
Bcfg2/Client/Tools: do not get bootstatus directly from the entry

### DIFF
--- a/src/lib/Bcfg2/Client/Tools/DebInit.py
+++ b/src/lib/Bcfg2/Client/Tools/DebInit.py
@@ -108,7 +108,7 @@ class DebInit(Bcfg2.Client.Tools.SvcTool):
     def InstallService(self, entry):
         """Install Service entry."""
         self.logger.info("Installing Service %s" % (entry.get('name')))
-        bootstatus = entry.get('bootstatus')
+        bootstatus = self.get_bootstatus(entry)
 
         # check if init script exists
         try:

--- a/src/lib/Bcfg2/Client/Tools/RcUpdate.py
+++ b/src/lib/Bcfg2/Client/Tools/RcUpdate.py
@@ -89,7 +89,7 @@ class RcUpdate(Bcfg2.Client.Tools.SvcTool):
     def InstallService(self, entry):
         """Install Service entry."""
         self.logger.info('Installing Service %s' % entry.get('name'))
-        bootstatus = entry.get('bootstatus')
+        bootstatus = self.get_bootstatus(entry)
         if bootstatus is not None:
             if bootstatus == 'on':
                 # make sure service is enabled on boot


### PR DESCRIPTION
Bootstatus is optional and should have the value of status if not specified.
This is handled by get_bootstatus.
