### PR TITLE
man/bcfg2.conf: add documentation for fam_blocking option

### DIFF
--- a/doc/man/bcfg2.conf.txt
+++ b/doc/man/bcfg2.conf.txt
@@ -46,6 +46,12 @@ filemonitor
 	fam
 	pseudo
 
+fam_blocking
+    Whether the server should block at startup until the file monitor
+    backend has processed all events. This can cause a slower startup,
+    but ensure that all files are recognized before the first client
+    is handled.
+
 ignore_files
     A comma-separated list of globs that should be ignored by the file
     monitor. Default values are::

--- a/man/bcfg2.conf.5
+++ b/man/bcfg2.conf.5
@@ -1,4 +1,4 @@
-.TH "BCFG2.CONF" "5" "March 18, 2013" "1.3" "Bcfg2"
+.TH "BCFG2.CONF" "5" "July 19, 2013" "1.3" "Bcfg2"
 .SH NAME
 bcfg2.conf \- Configuration parameters for Bcfg2
 .
@@ -75,6 +75,13 @@ pseudo
 .fi
 .UNINDENT
 .UNINDENT
+.TP
+.B fam_blocking
+.
+Whether the server should block at startup until the file monitor
+backend has processed all events. This can cause a slower startup,
+but ensure that all files are recognized before the first client
+is handled.
 .TP
 .B ignore_files
 A comma\-separated list of globs that should be ignored by the file


### PR DESCRIPTION
The fam_blocking server option currently is not documented, so we should add some notes to the bcfg2.conf manpage.
