### PR TITLE
Metadata: Don't update XML on gratuitous profile update

### DIFF
--- a/src/lib/Bcfg2/Server/Plugins/Metadata.py
+++ b/src/lib/Bcfg2/Server/Plugins/Metadata.py
@@ -978,18 +978,21 @@ class Metadata(Bcfg2.Server.Plugin.Metadata,
                 self.logger.error(msg)
                 raise Bcfg2.Server.Plugin.PluginExecutionError(msg)
 
-            profiles = [g for g in self.clientgroups[client]
-                        if g in self.groups and self.groups[g].is_profile]
-            if profiles != [profile]:
+            metadata = self.core.build_metadata(client)
+            if metadata.profile != profile:
                 self.logger.info("Changing %s profile from %s to %s" %
-                                 (client, profiles, profile))
+                                 (client, metadata.profile, profile))
                 self.update_client(client, dict(profile=profile))
                 if client in self.clientgroups:
-                    for prof in profiles:
-                        self.clientgroups[client].remove(prof)
+                    if metadata.profile in self.clientgroups[client]:
+                        self.clientgroups[client].remove(metadata.profile)
                     self.clientgroups[client].append(profile)
                 else:
                     self.clientgroups[client] = [profile]
+            else:
+                self.logger.debug(
+                    "Ignoring %s request to change profile from %s to %s"
+                    % (client, metadata.profile, profile))
         else:
             self.logger.info("Creating new client: %s, profile %s" %
                              (client, profile))

--- a/testsuite/Testsrc/Testlib/TestServer/TestPlugins/TestMetadata.py
+++ b/testsuite/Testsrc/Testlib/TestServer/TestPlugins/TestMetadata.py
@@ -885,6 +885,9 @@ class TestMetadata(_TestMetadata, TestClientRunHooks, TestDatabaseBacked):
         metadata = self.load_clients_data(metadata=self.load_groups_data())
         if not metadata._use_db:
             metadata.clients_xml.write = Mock()
+            metadata.core.build_metadata = Mock()
+            metadata.core.build_metadata.side_effect = \
+                lambda c: metadata.get_initial_metadata(c)
 
             metadata.set_profile("client1", "group2", None)
             mock_update_client.assert_called_with("client1",


### PR DESCRIPTION
Check to see if the profile that is being set by set_profile
exactly matches the existing profile list.  If it does, then avoid
writing out a new clients.xml. This simple optimization reduces
the amount of clients.xml rewriting that occurs if you have a
bunch of clients running bcfg2 -p at the same time (for example,
during a cluster rebuild).
