### PR TITLE
Reporting: have bcfg2-report-collector be explicit about detaching

### DIFF
--- a/src/lib/Bcfg2/Reporting/Collector.py
+++ b/src/lib/Bcfg2/Reporting/Collector.py
@@ -82,7 +82,7 @@ class ReportingCollector(object):
         """Startup the processing and go!"""
         self.terminate = threading.Event()
         atexit.register(self.shutdown)
-        self.context = daemon.DaemonContext()
+        self.context = daemon.DaemonContext(detach_process=True)
 
         if self.setup['daemon']:
             self.logger.debug("Daemonizing")


### PR DESCRIPTION
Following the same logic as 360ba2e7, we should be explicit about
the need to detach the bcfg2-report-collector process.

Side note: this bit me because I was starting the bcfg2 server
processes via SSH, and the way python-daemon checks for being
started by inetd is to see if stdin is a socket. (??)
