### PR TITLE
Multiprocessing: Always close RPC Listener sockets

### DIFF
--- a/src/lib/Bcfg2/Server/MultiprocessingCore.py
+++ b/src/lib/Bcfg2/Server/MultiprocessingCore.py
@@ -94,9 +94,9 @@ class RPCQueue(Bcfg2.Server.Plugin.Debuggable):
         try:
             self._queues[dest].put((listener.address,
                                     (method, args or [], kwargs or dict())))
-            conn = listener.accept()
-            self._blocking_listeners.remove(listener)
             try:
+                conn = listener.accept()
+                self._blocking_listeners.remove(listener)
                 while not self._terminate.is_set():
                     if conn.poll(self.poll_wait):
                         return conn.recv()


### PR DESCRIPTION
Moving Listener accept() into try..finally statement to fix race
condition where if system is out of file descriptors the socket
open will fail and will be put back into the available queue without
being properly closed.
