### PR TITLE
SELinux: Update the matchpathcon function to use the file's mode

### DIFF
--- a/src/lib/Bcfg2/Client/Tools/POSIX/base.py
+++ b/src/lib/Bcfg2/Client/Tools/POSIX/base.py
@@ -525,7 +525,8 @@ class POSIXTool(Bcfg2.Client.Tools.Tool):
             if entry.get("secontext") == "__default__":
                 try:
                     wanted_secontext = \
-                        selinux.matchpathcon(path, 0)[1].split(":")[2]
+                        selinux.matchpathcon(
+                            path, ondisk[stat.ST_MODE])[1].split(":")[2]
                 except OSError:
                     errors.append("%s has no default SELinux context" %
                                   entry.get("name"))


### PR DESCRIPTION
If you don't supply a mode to the selinux.matchpathcon() function, it
fails to properly look up the context in some circumstances related to
context patterns in the SELinux policy.  This change looks up the mode
and supplies it to the function.
