### PR TITLE
Tests: Fix tests after 9a6a231

### DIFF
--- a/testsuite/Testsrc/Testlib/TestServer/TestPlugins/TestMetadata.py
+++ b/testsuite/Testsrc/Testlib/TestServer/TestPlugins/TestMetadata.py
@@ -339,6 +339,7 @@ class TestXMLMetadataConfig(TestXMLFileBacked):
 
     @patch('Bcfg2.Utils.locked', Mock(return_value=False))
     @patch('fcntl.lockf', Mock())
+    @patch("Bcfg2.Server.Plugins.Metadata.XMLMetadataConfig.load_xml")
     @patch('os.open')
     @patch('os.fdopen')
     @patch('os.unlink')
@@ -346,7 +347,7 @@ class TestXMLMetadataConfig(TestXMLFileBacked):
     @patch('os.path.islink')
     @patch('os.readlink')
     def test_write_xml(self, mock_readlink, mock_islink, mock_rename,
-                       mock_unlink, mock_fdopen, mock_open):
+                       mock_unlink, mock_fdopen, mock_open, mock_load_xml):
         fname = "clients.xml"
         config = self.get_obj(fname)
         fpath = os.path.join(self.metadata.data, fname)
@@ -360,6 +361,7 @@ class TestXMLMetadataConfig(TestXMLFileBacked):
             mock_unlink.reset_mock()
             mock_fdopen.reset_mock()
             mock_open.reset_mock()
+            mock_load_xml.reset_mock()
 
         mock_islink.return_value = False
 
@@ -371,6 +373,7 @@ class TestXMLMetadataConfig(TestXMLFileBacked):
         self.assertTrue(mock_fdopen.return_value.write.called)
         mock_islink.assert_called_with(fpath)
         mock_rename.assert_called_with(tmpfile, fpath)
+        mock_load_xml.assert_called_with()
 
         # test: clients.xml.new is locked the first time we write it
         def rv(fname, mode):
@@ -389,6 +392,7 @@ class TestXMLMetadataConfig(TestXMLFileBacked):
         self.assertTrue(mock_fdopen.return_value.write.called)
         mock_islink.assert_called_with(fpath)
         mock_rename.assert_called_with(tmpfile, fpath)
+        mock_load_xml.assert_called_with()
 
         # test writing a symlinked clients.xml
         reset()
@@ -397,6 +401,7 @@ class TestXMLMetadataConfig(TestXMLFileBacked):
         mock_readlink.return_value = linkdest
         config.write_xml(fpath, get_clients_test_tree())
         mock_rename.assert_called_with(tmpfile, linkdest)
+        mock_load_xml.assert_called_with()
 
         # test failure of os.rename()
         reset()


### PR DESCRIPTION
I voted for 9a6a231, so I figured that I should fix the tests. :)

The addition of the call to load_xml in 9a6a231 causes the test to
fail because load_xml() expects to read a clients.xml file.  The
actual actual open calls in write_xml are dummied out with Mock,
so no file is written, and thus cannot be read back.  This commit
dummies out the load_xml and adds some more asserts for good measure.
