### PR TITLE
 Reporting: start a new thread for each import

### DIFF
--- a/src/lib/Bcfg2/Reporting/Collector.py
+++ b/src/lib/Bcfg2/Reporting/Collector.py
@@ -132,9 +132,6 @@ class ReportingCollector(object):
                     continue
 
                 store_thread = ReportingStoreThread(interaction, self.storage)
-                while len(threading.enumerate()) > 100:
-                    self.logger.info("more than 100 threads running, sleeping")
-                    time.sleep(1)
                 store_thread.start()
             except (SystemExit, KeyboardInterrupt):
                 self.logger.info("Shutting down")


### PR DESCRIPTION
When dealing with a high-latency database connection (eg. across a
WAN), the bcfg2-report-collector process can fall behind in its
import queue.  The imports are very much bound by the response
latency of the database server and not processing throughput.

This patch fires off a new thread for each database interaction.
The thread itself simply falls out of scope when the interaction
is finished processing.  The interaction object is still read from
the disk serially in order avoid having to create a locking mechanism
for that part of the process.

This change does potentially create greater load on the database
server, but ultimately the load is limited by rate at which the
bcfg2 server can generate work.
