### PR TITLE
Proxy:  Catch SSL errors and retry

### DIFF
--- a/src/lib/Bcfg2/Proxy.py
+++ b/src/lib/Bcfg2/Proxy.py
@@ -103,11 +103,7 @@ class RetryMethod(xmlrpclib._Method):
             except ProxyError:
                 err = sys.exc_info()[1]
                 msg = err
-            except SSL_ERROR:
-                err = sys.exc_info()[1]
-                msg = err
             except:
-                raise
                 etype, err = sys.exc_info()[:2]
                 msg = "Unknown failure: %s (%s)" % (err, etype.__name__)
             if msg:


### PR DESCRIPTION
The SSL library can throw an exception during the XMLRPC method call.  There
is no explicit except statement for this type of exception so they get raised
up and abort the client's processing. This patch catches the exception so that
normal retry processing occurs.

Typical traceback:
Traceback (most recent call last):
  File "/usr/sbin/bcfg2", line 29, in ?
    sys.exit(main())
  File "/usr/sbin/bcfg2", line 26, in main
    return Client(setup).run()
  File "/usr/lib/python2.4/site-packages/Bcfg2/Client/Client.py", line 256, in run
    rawconfig = self.get_config(times=times).decode('utf-8')
  File "/usr/lib/python2.4/site-packages/Bcfg2/Client/Client.py", line 225, in get_config
    self.run_probes(times=times)
  File "/usr/lib/python2.4/site-packages/Bcfg2/Client/Client.py", line 151, in run_probes
    probes = Bcfg2.Client.XML.XML(str(self.proxy.GetProbes()))
  File "/usr/lib/python2.4/site-packages/Bcfg2/Proxy.py", line 81, in **call**
    return _orig_Method.__call__(self, *args)
  File "/usr/lib64/python2.4/xmlrpclib.py", line 1096, in **call**
    return self.__send(self.__name, args)
  File "/usr/lib64/python2.4/xmlrpclib.py", line 1383, in __request
    verbose=self.__verbose
  File "/usr/lib/python2.4/site-packages/Bcfg2/Proxy.py", line 331, in request
    return self.parse_response(response)
  File "/usr/lib64/python2.4/xmlrpclib.py", line 1255, in parse_response
    return self._parse_response(file, None)
  File "/usr/lib64/python2.4/xmlrpclib.py", line 1276, in _parse_response
    response = file.read(1024)
  File "/usr/lib64/python2.4/httplib.py", line 480, in read
    s = self.fp.read(amt)
  File "/usr/lib64/python2.4/socket.py", line 303, in read
    data = self._sock.recv(recv_size)
  File "/usr/lib64/python2.4/site-packages/M2Crypto/SSL/Connection.py", line 217, in read
    return self._read_bio(size)
  File "/usr/lib64/python2.4/site-packages/M2Crypto/SSL/Connection.py", line 202, in _read_bio
    return m2.ssl_read(self.ssl, size, self._timeout)
M2Crypto.SSL.SSLError: (104, 'Connection reset by peer')
