### PR TITLE
Admin: Don't call dead Mode.__call__ code

### DIFF
--- a/src/lib/Bcfg2/Server/Admin/Compare.py
+++ b/src/lib/Bcfg2/Server/Admin/Compare.py
@@ -115,7 +115,6 @@ class Compare(Bcfg2.Server.Admin.Mode):
         return identical
 
     def __call__(self, args):
-        Bcfg2.Server.Admin.Mode.__call__(self, args)
         if len(args) == 0:
             self.errExit("No argument specified.\n"
                          "Please see bcfg2-admin compare help for usage.")

--- a/src/lib/Bcfg2/Server/Admin/Snapshots.py
+++ b/src/lib/Bcfg2/Server/Admin/Snapshots.py
@@ -27,7 +27,6 @@ class Snapshots(Bcfg2.Server.Admin.Mode):
         self.cfile = self.configfile
 
     def __call__(self, args):
-        Bcfg2.Server.Admin.Mode.__call__(self, args)
         if len(args) == 0 or args[0] == '-h':
             print(self.__usage__)
             raise SystemExit(0)


### PR DESCRIPTION
In 9eb3db84, Bcfg2.Server.Admin.Mode.**call**() was changed from
pass to raise a NotImplementedError.  This causes bcfg2-admin
compare and bcfg2-admin snapshots to fail because they call
Bcfg2.Server.Admin.Mode.**call**() right away.  Since that method
didn't do anything anyway, it seems expediant to just avoid the call
altogether.
