### PR TITLE
NagiosGen: Sort the hostgroup list

### DIFF
--- a/src/lib/Bcfg2/Server/Plugins/NagiosGen.py
+++ b/src/lib/Bcfg2/Server/Plugins/NagiosGen.py
@@ -53,7 +53,7 @@ class NagiosGen(Plugin, Generator):
 
         if host_groups:
             host_config.append(self.line_fmt % ("hostgroups",
-                                                ",".join(host_groups)))
+                                                ",".join(sorted(host_groups))))
 
         # read the config
         xtra = dict()


### PR DESCRIPTION
This prevents the hostgroup list from flipping at random.
