### PR TITLE
Options: Finalize once

### DIFF
--- a/src/lib/Bcfg2/Options/Parser.py
+++ b/src/lib/Bcfg2/Options/Parser.py
@@ -246,8 +246,8 @@ class Parser(argparse.ArgumentParser):
             self._set_defaults()
             self.parse_known_args(args=self.argv, namespace=self.namespace)
             self._parse_config_options()
-            self._finalize()
         self._parse_config_options()
+        self._finalize()
 
         # phase 4: fix up <repository> macros
         repo = getattr(self.namespace, "repository", repository.default)


### PR DESCRIPTION
If finalize is called early, then some options will not be parsed
but instead always take the default value (observed with
reporting.transport).  Calling finalize once at the end of the
processing lets all options take the values they were assigned in the
config file.
