### PR TITLE
Essential package list cache is not cleared when Packages is refreshed

### DIFF
--- a/src/lib/Bcfg2/Server/Plugins/Packages/Apt.py
+++ b/src/lib/Bcfg2/Server/Plugins/Packages/Apt.py
@@ -77,6 +77,7 @@ class AptSource(Source):
     def read_files(self):
         bdeps = dict()
         bprov = dict()
+        self.essentialpkgs = set()
         depfnames = ['Depends', 'Pre-Depends']
         if self.recommended:
             depfnames.append('Recommends')


### PR DESCRIPTION
When `<Source essential="true">` is set in `Packages/sources.xml`, the essential package list get recorded in the Packages cache. This set is then always read from cache and the list is never reset when`bcfg2-admin xcmd Packages.Refresh` is run.

If the essential attribute is set to false, the Packages plugin will not forget about the essential package list unless the cache is removed and the server restarted.

The attached patch should reset the essential package list when the Packages plugin is refreshed.
