### PR TITLE
Enable bcfg2-yum-helper to depsolve for arches incompatible with server

### DIFF
--- a/src/sbin/bcfg2-yum-helper
+++ b/src/sbin/bcfg2-yum-helper
@@ -62,6 +62,10 @@ class YumHelper(object):
         # pylint: enable=E1121,W0212
         self.logger = logging.getLogger(self.__class__.__name__)
 
+    def setarch(self, arch):
+        """ Configure an arch other than the bcfg2 server arch for dep
+        resolution. """
+        self.yumbase.arch.setup_arch(arch=arch)
 
 class DepSolver(YumHelper):
     """ Yum dependency solver.  This is used for operations that only
@@ -326,6 +330,11 @@ def main():
                          sys.exc_info()[1])
             rv = 2
         try:
+            # if provided, set client arch for dependency resolution
+            arch = data.get('arch', None)
+            if arch is not None:
+                depsolver.setarch(arch)
+
             depsolver.groups = data['groups']
             (packages, unknown) = depsolver.complete(
                 [pkg_to_tuple(p) for p in data['packages']])


### PR DESCRIPTION
By default, the yum dependency resolver uses the host's architecture
to filter compatible packages.  This prevents dependency resolution
when the bcfg2 client's architecture is incompatible with the
server's.

This workaround checks the <Arch/> element for each of the client's yum
sources, and if they are all identical, passes that architecture to
bcfg2-yum-helper to override the default.

The rpmUtils.arch module may only be configured for a single
architecture.  If multiple architectures are configured in yum
sources, we don't know which one to pick, so use the default behavior
instead.
