### PR TITLE
misc/bcfg2.spec Remove duplicate checks for systemd in RPM scriptlets

### DIFF
--- a/misc/bcfg2.spec
+++ b/misc/bcfg2.spec
@@ -30,7 +30,7 @@
 
 Name:             bcfg2
 Version:          1.3.4
-Release:          1%{?_pre_rc}%{?dist}
+Release:          2%{?_pre_rc}%{?dist}
 Summary:          A configuration management system
 
 %if 0%{?suse_version}
@@ -768,6 +768,9 @@ sed "s@http://www.w3.org/2001/xml.xsd@file://$(pwd)/schemas/xml.xsd@" \
 
 
 %changelog
+* Wed Apr 23 2014 Jonathan S. Billings <jsbillin@umich.edu> - 1.3.4-2
+- Fixed RPM scriptlet logic for el6 vs. Fedora init commands
+
 * Sun Apr  6 2014 John Morris <john@zultron.com> - 1.3.4-1
 - New upstream release
 


### PR DESCRIPTION
In the RPM scriptlets, there's first a check for fedora 18 or greater,
then if that's not true, a check for fedora 16 or greater.  Due to
some bug in how nested %if statements work in RPM scriptlets, the
second test is evaluating true even on non-Fedora systems, which is
leading to systemd commands being put in RHEL6 RPM scriptlets.

This change removes the second check.  If there needed to be a check
for versions of Fedora 16 and 17, they will no longer work, but since
neither of those are supported versions of Fedora, I suspect we don't
need to include logic for them.
