### PR TITLE
Default to only (En|De)crypt vars that need it

### DIFF
--- a/src/lib/Bcfg2/Server/Encryption.py
+++ b/src/lib/Bcfg2/Server/Encryption.py
@@ -372,7 +372,7 @@ class CfgDecryptor(Decryptor):
 
 class PropertiesCryptoMixin(object):
     """ Mixin to provide some common methods for Properties crypto """
-    default_xpath = '//*'
+    default_xpath = '//*[@encrypted]'
 
     def _get_elements(self, xdata):
         """ Get the list of elements to encrypt or decrypt """
@@ -460,7 +460,6 @@ class PropertiesEncryptor(Encryptor, PropertiesCryptoMixin):
 
 class PropertiesDecryptor(Decryptor, PropertiesCryptoMixin):
     """ decryptor class for Properties files """
-    default_xpath = '//*[@encrypted]'
 
     def decrypt(self):
         decrypted_any = False


### PR DESCRIPTION
For both Encrypting and Decrypting of Properties
files, we should by default only attempt to execute
on elements that have an "encrypted" attribute defined.

The code will already attempt to encrypt every element
if nothing in the current document matches this xpath,
which catches the case of a user trying to fully
encrypt a completely new properties file.
