### PR TITLE
Packages/Apt: Essential could be "no"

### DIFF
--- a/src/lib/Bcfg2/Server/Plugins/Packages/Apt.py
+++ b/src/lib/Bcfg2/Server/Plugins/Packages/Apt.py
@@ -107,7 +107,8 @@ class AptSource(Source):
                     self.pkgnames.add(pkgname)
                     bdeps[barch][pkgname] = []
                 elif words[0] == 'Essential' and self.essential:
-                    self.essentialpkgs.add(pkgname)
+                    if words[1].strip() == 'yes':
+                        self.essentialpkgs.add(pkgname)
                 elif words[0] in depfnames:
                     vindex = 0
                     for dep in words[1].split(','):


### PR DESCRIPTION
The "Essential" field in the package control fields could be "yes" or "no".
Only yes sould define the package as essential. The value "no" sould be
handled same as not having the field at all.
