### PR TITLE
Use PYVERSION in Makefile and gen-prototypes consistently

### DIFF
--- a/solaris/Makefile
+++ b/solaris/Makefile
@@ -2,14 +2,14 @@
 
 PYTHON="/usr/local/bin/python"
 VERS=1.3.4-1
-PYVERSION := $(shell $(PYTHON) -c "import sys; print sys.version[0:3]")
+export PYVERSION := $(shell $(PYTHON) -c "import sys; print sys.version[0:3]")
 
 default: clean package
 
 package:
 	-mkdir  tmp tmp/bcfg2-server tmp/bcfg2
 	-mkdir -p build/lib/$(PYVERSION)/site-packages
-	-cd ../ && PYTHONPATH=$(PYTHONPATH):$(PWD)/build/lib/python2.6/site-packages/ $(PYTHON) setup.py install --single-version-externally-managed --record=/dev/null --prefix=$(PWD)/build
+	-cd ../ && PYTHONPATH=$(PYTHONPATH):$(PWD)/build/lib/python$(PYVERSION)/site-packages/ $(PYTHON) setup.py install --single-version-externally-managed --record=/dev/null --prefix=$(PWD)/build
 	#setuptools appears to use a restictive umask
 	-chmod -R o+r build/
 	-cat build/bin/bcfg2 | sed -e 's!/usr/bin/python!$(PYTHON)!' > build/bin/bcfg2.new && mv build/bin/bcfg2.new build/bin/bcfg2

--- a/solaris/gen-prototypes.sh
+++ b/solaris/gen-prototypes.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 cd build
-PP="./lib/python/site-packages/"
+PP="./lib/python${PYVERSION}/site-packages/"
 
 #bcfg2
 echo "i pkginfo=./pkginfo.bcfg2" >  ../prototype.tmp


### PR DESCRIPTION
PYVERSION is already being set in the Makefile but wasn't being used
when setup.py gets invoked.
Use PYVERSION in gen-prototypes to generate complete packages.
