### PR TITLE
Server/Admin: fatal errors should go to stderr

### DIFF
--- a/src/lib/Bcfg2/Server/Admin/__init__.py
+++ b/src/lib/Bcfg2/Server/Admin/__init__.py
@@ -58,7 +58,7 @@ class Mode(object):
 
     def errExit(self, emsg):
         """ exit with an error """
-        print(emsg)
+        sys.stderr.write('%s\n' % emsg)
         raise SystemExit(1)
 
     def load_stats(self, client):


### PR DESCRIPTION
If an error occurs, that leads to an termination of the process,
this error should be printed to stderr.
