### PR TITLE
Reporting: do not duplicate isstale functionality

### DIFF
--- a/src/lib/Bcfg2/Reporting/templates/clients/detailed-list.html
+++ b/src/lib/Bcfg2/Reporting/templates/clients/detailed-list.html
@@ -32,7 +32,7 @@ This is needed for Django versions less than 1.5
     <td class='right_column_narrow'>{{ entry.bad_count }}</td>
     <td class='right_column_narrow'>{{ entry.modified_count }}</td>
     <td class='right_column_narrow'>{{ entry.extra_count }}</td>
-    <td class='right_column'><span {% if entry.timestamp|isstale:entry_max %}class='dirty-lineitem'{% endif %}>{{ entry.timestamp|date:"Y-m-d\&\n\b\s\p\;H:i"|safe }}</span></td>
+    <td class='right_column'><span {% if entry.isstale %}class='dirty-lineitem'{% endif %}>{{ entry.timestamp|date:"Y-m-d\&\n\b\s\p\;H:i"|safe }}</span></td>
     <td class='right_column_wide'>
        {% if entry.server %}
          <a href='{% add_url_filter server=entry.server %}'>{{ entry.server }}</a>

--- a/src/lib/Bcfg2/Reporting/templatetags/bcfg2_tags.py
+++ b/src/lib/Bcfg2/Reporting/templatetags/bcfg2_tags.py
@@ -189,19 +189,6 @@ def build_metric_list(mdict):
 
 
 @register.filter
-def isstale(timestamp, entry_max=None):
-    """
-    Check for a stale timestamp
-
-    Compares two timestamps and returns True if the
-    difference is greater then 24 hours.
-    """
-    if not entry_max:
-        entry_max = datetime.now()
-    return entry_max - timestamp > timedelta(hours=24)
-
-
-@register.filter
 def sort_interactions_by_name(value):
     """
     Sort an interaction list by client name
@@ -318,7 +305,7 @@ def determine_client_state(entry):
     dirty. If the client is reporting dirty, this will figure out just
     _how_ dirty and adjust the color accordingly.
     """
-    if isstale(entry.timestamp):
+    if entry.isstale():
         return "stale-lineitem"
     if entry.state == 'clean':
         if entry.extra_count > 0:


### PR DESCRIPTION
The interaction entries have a isstale() method, we do not need a
template tag, that tries to figure out this on its own. The isstale()
method works even better: It knows, if the interaction is the current
interaction and compares the timestamp to the current time or (if it is
not the current one) it compares the timestamp to the timestamp of the
next interaction. So using the method of the model, you can browse the
interaction history and see, if the host was stale some time in the
past. Previously all interactions more than 24h ago were marked stale.
