### PR TITLE
doc: replace tabs with spaces

### DIFF
--- a/schemas/acl.xsd
+++ b/schemas/acl.xsd
@@ -3,7 +3,7 @@
   <xsd:annotation>
     <xsd:documentation>
       acl config schema for bcfg2
-	  Matt Schwager
+      Matt Schwager
     </xsd:documentation>
   </xsd:annotation>
 

--- a/schemas/types.xsd
+++ b/schemas/types.xsd
@@ -487,9 +487,9 @@
       <xsd:annotation>
         <xsd:documentation>
           This field is typically used to record general information
-	  about the account or its user(s) such as their real name
-	  and phone number. If this is not set, the GECOS will be
-	  the same as the username.
+          about the account or its user(s) such as their real name
+          and phone number. If this is not set, the GECOS will be
+          the same as the username.
         </xsd:documentation>
       </xsd:annotation>
     </xsd:attribute>


### PR DESCRIPTION
Just another quick doc fix. This removes the block quote warning:

```
<xmlschema>:2: WARNING: Block quote ends without a blank line; unexpected unindent.
```
