### PR TITLE
Options/Types: fix comma_dict parsing

### DIFF
--- a/src/lib/Bcfg2/Options/Types.py
+++ b/src/lib/Bcfg2/Options/Types.py
@@ -38,9 +38,11 @@ def comma_dict(value):
         for item in items:
             if '=' in item:
                 key, value = item.split(r'=', 1)
-                try:
-                    result[key] = bool(value)
-                except ValueError:
+                if value == 'False':
+                    result[key] = False
+                elif value == 'True':
+                    result[key] = False
+                else:
                     try:
                         result[key] = int(value)
                     except ValueError:


### PR DESCRIPTION
bool() does not seem to raise a ValueError on any string, so we need to
check manually whether the value is a bool or not.
