### PR TITLE
Server/Plugins/Decisions: fix typo

### DIFF
--- a/src/lib/Bcfg2/Server/Plugins/Decisions.py
+++ b/src/lib/Bcfg2/Server/Plugins/Decisions.py
@@ -9,7 +9,7 @@ import Bcfg2.Server.FileMonitor
 class DecisionFile(Bcfg2.Server.Plugin.StructFile):
     """ Representation of a Decisions XML file """
 
-    def get_decisions(self, metadata):
+    def get_decision(self, metadata):
         """ Get a list of whitelist or blacklist tuples """
         if self.xdata is None:
             # no white/blacklist has been read yet, probably because


### PR DESCRIPTION
This fixes this traceback:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/Bcfg2/Server/Core.py", line 818, in GetDecisions
    result.extend(plugin.GetDecisions(metadata, mode))
  File "/usr/lib/python2.7/dist-packages/Bcfg2/Server/Plugins/Decisions.py", line 34, in GetDecisions
    return getattr(self, mode).get_decision(metadata)
AttributeError: 'DecisionFile' object has no attribute 'get_decision'
```
