### PR TITLE
Tools/Action: fix typo

### DIFF
--- a/src/lib/Bcfg2/Client/Tools/Action.py
+++ b/src/lib/Bcfg2/Client/Tools/Action.py
@@ -36,7 +36,7 @@ class Action(Bcfg2.Client.Tools.Tool):
             shell = True
             shell_string = '(in shell) '
 
-        if not Bcfg2.Options.setup.dryrun:
+        if not Bcfg2.Options.setup.dry_run:
             if Bcfg2.Options.setup.interactive:
                 prompt = ('Run Action %s%s, %s: (y/N): ' %
                           (shell_string, entry.get('name'),


### PR DESCRIPTION
This fixes this traceback:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/Bcfg2/Client/Tools/__init__.py", line 223, in Install
    states[entry] = func(entry)
  File "/usr/lib/python2.7/dist-packages/Bcfg2/Client/Tools/Action.py", line 71, in InstallAction
    return self.RunAction(entry)
  File "/usr/lib/python2.7/dist-packages/Bcfg2/Client/Tools/Action.py", line 39, in RunAction
    if not Bcfg2.Options.setup.dryrun:
AttributeError: 'Namespace' object has no attribute 'dryrun'
```
