### PR TITLE
Options/Commmon: remove default values for ssl-key/ssl-cert

### DIFF
--- a/src/lib/Bcfg2/Client/Proxy.py
+++ b/src/lib/Bcfg2/Client/Proxy.py
@@ -291,9 +291,14 @@ class ComponentProxy(xmlrpclib.ServerProxy):
     """Constructs proxies to components. """
 
     options = [
-        Bcfg2.Options.Common.location, Bcfg2.Options.Common.ssl_key,
-        Bcfg2.Options.Common.ssl_cert, Bcfg2.Options.Common.ssl_ca,
+        Bcfg2.Options.Common.location, Bcfg2.Options.Common.ssl_ca,
         Bcfg2.Options.Common.password, Bcfg2.Options.Common.client_timeout,
+        Bcfg2.Options.PathOption(
+            '--ssl-key', cf=('communication', 'key'), dest="key",
+            help='Path to SSL key'),
+        Bcfg2.Options.PathOption(
+            cf=('communication', 'certificate'), dest="cert",
+            help='Path to SSL certificate'),
         Bcfg2.Options.Option(
             "-u", "--user", default="root", cf=('communication', 'user'),
             help='The user to provide for authentication'),

--- a/src/lib/Bcfg2/Options/Common.py
+++ b/src/lib/Bcfg2/Options/Common.py
@@ -107,16 +107,6 @@ class Common(object):
         '-x', '--password', cf=('communication', 'password'),
         metavar='<password>', help="Communication Password")
 
-    #: Path to SSL key
-    ssl_key = PathOption(
-        '--ssl-key', cf=('communication', 'key'), dest="key",
-        help='Path to SSL key', default="/etc/pki/tls/private/bcfg2.key")
-
-    #: Path to SSL certificate
-    ssl_cert = PathOption(
-        cf=('communication', 'certificate'), dest="cert",
-        help='Path to SSL certificate', default="/etc/pki/tls/certs/bcfg2.crt")
-
     #: Path to SSL CA certificate
     ssl_ca = PathOption(
         cf=('communication', 'ca'), help='Path to SSL CA Cert')

--- a/src/lib/Bcfg2/Server/Core.py
+++ b/src/lib/Bcfg2/Server/Core.py
@@ -1370,8 +1370,15 @@ class NetworkCore(Core):
     daemonized, etc."""
     options = Core.options + [
         Bcfg2.Options.Common.daemon, Bcfg2.Options.Common.syslog,
-        Bcfg2.Options.Common.location, Bcfg2.Options.Common.ssl_key,
-        Bcfg2.Options.Common.ssl_cert, Bcfg2.Options.Common.ssl_ca,
+        Bcfg2.Options.Common.location, Bcfg2.Options.Common.ssl_ca,
+        Bcfg2.Options.PathOption(
+            '--ssl-key', cf=('communication', 'key'), dest="key",
+            help='Path to SSL key',
+            default="/etc/pki/tls/private/bcfg2.key"),
+        Bcfg2.Options.PathOption(
+            cf=('communication', 'certificate'), dest="cert",
+            help='Path to SSL certificate',
+            default="/etc/pki/tls/certs/bcfg2.crt"),
         Bcfg2.Options.BooleanOption(
             '--listen-all', cf=('server', 'listen_all'), default=False,
             help="Listen on all interfaces"),


### PR DESCRIPTION
With these default values it is impossible to remove the ssl key and ssl cert
from the configuration and use password auth.
