### PR TITLE
YUM: Add options to enable and disable Yum plugins

### DIFF
--- a/src/lib/Bcfg2/Client/Tools/YUM.py
+++ b/src/lib/Bcfg2/Client/Tools/YUM.py
@@ -191,6 +191,10 @@ class YUM(Bcfg2.Client.Tools.PkgTool):
         self.logger.debug("Yum: Reinstall on verify fail: %s" % self.do_reinst)
         self.logger.debug("Yum: installonlypkgs: %s" % self.installonlypkgs)
         self.logger.debug("Yum: verify_flags: %s" % self.verify_flags)
+        self.logger.debug("Yum: disabled_plugins: %s" % 
+                          self.setup["yum_disabled_plugins"])
+        self.logger.debug("Yum: enabled_plugins: %s" % 
+                          self.setup["yum_enabled_plugins"])
 
     def _loadYumBase(self, setup=None, logger=None):
         ''' this may be called before PkgTool.__init__() is called on
@@ -215,6 +219,12 @@ class YUM(Bcfg2.Client.Tools.PkgTool):
             debuglevel = 2
         else:
             debuglevel = 0
+
+        if setup['yum_disabled_plugins']:
+            rv.preconf.disabled_plugins = setup['yum_disabled_plugins']
+
+        if setup['yum_enabled_plugins']:
+            rv.preconf.enabled_plugins = setup['yum_enabled_plugins']
 
         # pylint: disable=E1121,W0212
         try:

--- a/src/lib/Bcfg2/Options.py
+++ b/src/lib/Bcfg2/Options.py
@@ -1099,6 +1099,16 @@ CLIENT_YUM_VERIFY_FLAGS = \
            cf=('YUM', 'verify_flags'),
            deprecated_cf=('YUMng', 'verify_flags'),
            cook=list_split)
+CLIENT_YUM_DISABLED_PLUGINS = \
+    Option("YUM disabled plugins",
+           default=[],
+           cf=('YUM', 'disabled_plugins'),
+           cook=list_split)
+CLIENT_YUM_ENABLED_PLUGINS = \
+    Option("YUM enabled plugins",
+           default=[],
+           cf=('YUM', 'enabled_plugins'),
+           cook=list_split)
 CLIENT_POSIX_UID_WHITELIST = \
     Option("UID ranges the POSIXUsers tool will manage",
            default=[],
@@ -1280,6 +1290,8 @@ DRIVER_OPTIONS = \
          yum_version_fail_action=CLIENT_YUM_VERSION_FAIL_ACTION,
          yum_verify_fail_action=CLIENT_YUM_VERIFY_FAIL_ACTION,
          yum_verify_flags=CLIENT_YUM_VERIFY_FLAGS,
+         yum_disabled_plugins=CLIENT_YUM_DISABLED_PLUGINS,
+         yum_enabled_plugins=CLIENT_YUM_ENABLED_PLUGINS,
          posix_uid_whitelist=CLIENT_POSIX_UID_WHITELIST,
          posix_gid_whitelist=CLIENT_POSIX_GID_WHITELIST,
          posix_uid_blacklist=CLIENT_POSIX_UID_BLACKLIST,


### PR DESCRIPTION
Adds two options you can define:
- disabled_plugins: A comma-separated list of plugins to disable
- enabled_plugins: A comma-separated list of plugins to enable

This allows you to run bcfg2 with certain plugins enabled or disabled
when they're not set that way in the yum configuration.  This is
useful because the Bcfg2 YUM plugin is initialized before it can read
in any files that might overwrite yum plugin configuration.
