### PR TITLE
Client/Proxy: use keyword arguments to match the correct order

### DIFF
--- a/src/lib/Bcfg2/Client/Proxy.py
+++ b/src/lib/Bcfg2/Client/Proxy.py
@@ -332,11 +332,12 @@ class ComponentProxy(xmlrpclib.ServerProxy):
                 path)
         else:
             url = Bcfg2.Options.setup.server
-        ssl_trans = XMLRPCTransport(Bcfg2.Options.setup.key,
-                                    Bcfg2.Options.setup.cert,
-                                    Bcfg2.Options.setup.ca,
-                                    Bcfg2.Options.setup.ssl_cns,
-                                    Bcfg2.Options.setup.client_timeout,
-                                    Bcfg2.Options.setup.protocol)
+        ssl_trans = XMLRPCTransport(
+            key=Bcfg2.Options.setup.key,
+            cert=Bcfg2.Options.setup.cert,
+            ca=Bcfg2.Options.setup.ca,
+            scns=Bcfg2.Options.setup.ssl_cns,
+            timeout=Bcfg2.Options.setup.client_timeout,
+            protocol=Bcfg2.Options.setup.protocol)
         xmlrpclib.ServerProxy.__init__(self, url,
                                        allow_none=True, transport=ssl_trans)


### PR DESCRIPTION
The XMLRPCTransport **init** method defines several arguments with default
values. The current call missed the use_datetime argument, so that the
client_timeout will set the use_datetime paramenter and the protocol option
was used as timeout (does not work, because a float is required and raises
an exception).
