### PR TITLE
Support .socket and .target for systemctl

### DIFF
--- a/src/lib/Bcfg2/Client/Tools/Systemd.py
+++ b/src/lib/Bcfg2/Client/Tools/Systemd.py
@@ -16,8 +16,8 @@ class Systemd(Bcfg2.Client.Tools.SvcTool):
     def get_svc_name(self, service):
         """Append .service to name if name doesn't specify a unit type."""
         svc = service.get('name')
-        if svc.endswith(('.service', '.socket', '.device', '.mount', 
-                         '.automount', '.swap', '.target', '.path', 
+        if svc.endswith(('.service', '.socket', '.device', '.mount',
+                         '.automount', '.swap', '.target', '.path',
                          '.timer', '.snapshot', '.slice', '.scope')):
             return svc
         else:


### PR DESCRIPTION
If a service name ends with .service, .socket, or .target, do not
automatically add ".service" to the end when calling systemctl.
This change allows users to manage sockets and targets using systemctl.
