### PR TITLE
Server/Core: also shutdown on exceptions during fam blocking

### DIFF
--- a/src/lib/Bcfg2/Server/Core.py
+++ b/src/lib/Bcfg2/Server/Core.py
@@ -847,14 +847,14 @@ class BaseCore(object):
 
             for plug in self.plugins_by_type(Threaded):
                 plug.start_threads()
+
+            if self.debug_flag:
+                self.set_debug(None, self.debug_flag)
+            self.block_for_fam_events()
+            self._block()
         except:
             self.shutdown()
             raise
-
-        if self.debug_flag:
-            self.set_debug(None, self.debug_flag)
-        self.block_for_fam_events()
-        self._block()
 
     def _daemonize(self):
         """ Daemonize the server and write the pidfile.  This must be


### PR DESCRIPTION
Previously the server got stuck, if a keyboard interrupt occured during
`block_for_fam_events`. The `KeyboardInterrupt` exception was only handled
in the executable and it does not call shutdown for the Core. So the
running `fam_thread` does not get killed and the main thread waits for it.
