### PR TITLE
fix keyboard interrupt during intial event handling

### DIFF
--- a/src/lib/Bcfg2/Server/FileMonitor/__init__.py
+++ b/src/lib/Bcfg2/Server/FileMonitor/__init__.py
@@ -234,6 +234,8 @@ class FileMonitor(Debuggable):
                         self.handles[event.requestID]))
         try:
             self.handles[event.requestID].HandleEvent(event)
+        except KeyboardInterrupt:
+            raise
         except:  # pylint: disable=W0702
             err = sys.exc_info()[1]
             LOGGER.error("Error in handling of event %s for %s: %s" %

--- a/src/lib/Bcfg2/Server/Plugins/Packages/Source.py
+++ b/src/lib/Bcfg2/Server/Plugins/Packages/Source.py
@@ -364,7 +364,7 @@ class Source(Bcfg2.Server.Plugin.Debuggable):  # pylint: disable=R0902
             if os.path.exists(self.cachefile):
                 try:
                     self.load_state()
-                except:
+                except (OSError, cPickle.UnpicklingError):
                     err = sys.exc_info()[1]
                     self.logger.error("Packages: Cachefile %s load failed: %s"
                                       % (self.cachefile, err))


### PR DESCRIPTION
This removes some wildcard except handler because this drops some
KeyboardInterrupt exceptions (for example previously a KeyboardInterrupt
during the loading of the cache for Packages resulted in a fallback to
file read).
