### PR TITLE
Server/Plugins/ALC: do not require a name attribute

### DIFF
--- a/src/lib/Bcfg2/Server/Plugins/ACL.py
+++ b/src/lib/Bcfg2/Server/Plugins/ACL.py
@@ -62,6 +62,7 @@ def ip_matches(ip, entry):
 
 class IPACLFile(Bcfg2.Server.Plugin.XMLFileBacked):
     """ representation of ACL ip.xml, for IP-based ACLs """
+    __identifier__ = None
     actions = dict(Allow=True,
                    Deny=False,
                    Defer=None)


### PR DESCRIPTION
This fixes a bcfg2-lint error. The name attribute at the top level element is not documented and not used, so we should not require it.

Additional to the actually problem, `bcfg2-lint` has another bug. It does not notice this error (only echos error message but return code is 0) because the `FileMonitor` simply catches all exceptions. Maybe we want to add the possibility to reraise the exceptions in `FileMonitor.handle_one_event`.
