### PR TITLE
Fix missing import line for django.core.management.

### DIFF
--- a/src/lib/Bcfg2/DBSettings.py
+++ b/src/lib/Bcfg2/DBSettings.py
@@ -8,6 +8,7 @@ import Bcfg2.Options
 
 try:
     import django
+    import django.core.management
     import django.conf
     HAS_DJANGO = True
 except ImportError:


### PR DESCRIPTION
This appears to be a nested package and I receive tracebacks on django 1.6.5 with bcfg2 1.4.0pre1 without this import here.
