### PR TITLE
Options/Types: add abbility to set empty lists

### DIFF
--- a/src/lib/Bcfg2/Options/Types.py
+++ b/src/lib/Bcfg2/Options/Types.py
@@ -19,12 +19,16 @@ def path(value):
 def comma_list(value):
     """ Split a comma-delimited list, with optional whitespace around
     the commas."""
+    if value == '':
+        return []
     return _COMMA_SPLIT_RE.split(value)
 
 
 def colon_list(value):
     """ Split a colon-delimited list.  Whitespace is not allowed
     around the colons. """
+    if value == '':
+        return []
     return value.split(':')
 
 


### PR DESCRIPTION
We have some lists with default values, so someone maybe want to set an empty
list from the config. Previously this was not possible, because an empty string
results in a list with an empty string as element. This fixes this problem.

This should not interfere with #211.
