### PR TITLE
Yum.py: Fix traceback when arch missing

### DIFF
--- a/src/lib/Bcfg2/Server/Plugins/Packages/Yum.py
+++ b/src/lib/Bcfg2/Server/Plugins/Packages/Yum.py
@@ -1293,6 +1293,8 @@ class YumSource(Source):
                     package not in self.blacklist and
                     (len(self.whitelist) == 0 or package in self.whitelist))
         except KeyError:
+            self.logger.debug("Packages: Unable to find %s for arch %s" %
+                              (package, arch[0]))
             return False
     is_package.__doc__ = Source.is_package.__doc__
 

--- a/src/lib/Bcfg2/Server/Plugins/Packages/Yum.py
+++ b/src/lib/Bcfg2/Server/Plugins/Packages/Yum.py
@@ -1287,10 +1287,13 @@ class YumSource(Source):
         arch = [a for a in self.arches if a in metadata.groups]
         if not arch:
             return False
-        return ((package in self.packages['global'] or
-                 package in self.packages[arch[0]]) and
-                package not in self.blacklist and
-                (len(self.whitelist) == 0 or package in self.whitelist))
+        try:
+            return ((package in self.packages['global'] or
+                     package in self.packages[arch[0]]) and
+                    package not in self.blacklist and
+                    (len(self.whitelist) == 0 or package in self.whitelist))
+        except KeyError:
+            return False
     is_package.__doc__ = Source.is_package.__doc__
 
     def get_vpkgs(self, metadata):


### PR DESCRIPTION
Sometimes repositories may not contain packages for a specific
architecture group. This handles that case gracefully instead of causing
a traceback and failing to bind all Package entries.

Signed-off-by: Sol Jerome <sol.jerome@gmail.com>