### PR TITLE
Bundler: add modification support to Bundle dependencies

### DIFF
--- a/doc/server/plugins/structures/bundler/bcfg2.txt
+++ b/doc/server/plugins/structures/bundler/bcfg2.txt
@@ -16,7 +16,7 @@ entries between Bundler and Rules.
 .. code-block:: xml
 
   <Bundle>
-    <Bundle name="bcfg2-server-base.xml"/>
+    <RequiredBundle name="bcfg2-server-base.xml"/>
 
     <Path name="/etc/pki/tls/private/bcfg2.key"/>
     <Path name="/etc/sysconfig/bcfg2-server"/>

--- a/doc/server/plugins/structures/bundler/index.txt
+++ b/doc/server/plugins/structures/bundler/index.txt
@@ -151,20 +151,20 @@ See :ref:`bcfg2-info <server-bcfg2-info>` for more details.
 Dependencies
 ============
 
-Dependencies on other bundles can be specified by adding an empty
-bundle tag that adds another bundle by name, e.g.:
+Dependencies on other bundles can be specified by adding an
+RequiredBundle tag that adds another bundle by name, e.g.:
 
 .. code-block:: xml
 
     <Bundle>
-      <Bundle name="nfs-client"/>
+      <RequiredBundle name="nfs-client"/>
       ...
     </Bundle>
 
 The dependent bundle is added to the list of bundles sent to the
-client, *not* to the parent bundle itself.  In other words, if an
-entry in the dependent bundle changes, Services are restarted and
-Actions are run in the dependent bundle *only*.  An example:
+client, *not* to the parent bundle itself. If you want to propagate
+the modification flag from the required bundle, you can add
+``modification="inherit"`` to the RequiredBundle tag. An example:
 
 ``nfs-client.xml``:
 
@@ -182,7 +182,7 @@ Actions are run in the dependent bundle *only*.  An example:
 .. code-block:: xml
 
     <Bundle>
-      <Bundle name="nfs-client"/>
+      <RequiredBundle name="nfs-client"/>
 
       <Path name="/mnt/home"/>
       <Path name="/etc/auto.master"/>
@@ -193,9 +193,13 @@ Actions are run in the dependent bundle *only*.  An example:
 
 If a new ``nfs-utils`` package was installed, the ``nfslock``,
 ``rpcbind``, and ``nfs`` services would be restarted, but *not* the
-``autofs`` service.  Similarly, if a new ``/etc/auto.misc`` file was
-sent out, the ``autofs`` service would be restarted, but the
-``nfslock``, ``rpcbind``, and ``nfs`` services would not be restarted.
+``autofs`` service. If you would add ``modification="inherit`` to
+the RequiredBundle tag, you would ensure the propagation of the
+modification flag and the ``autofs`` service would be restarted,
+too. But if a new ``/etc/auto.misc`` file was sent out, *only* the
+``autofs`` service would be restarted, but the ``nfslock``,
+``rpcbind``, and ``nfs`` services would not be restarted
+(independent of the ``modification`` flag).
 
 Altsrc
 ======

--- a/doc/server/plugins/structures/bundler/index.txt
+++ b/doc/server/plugins/structures/bundler/index.txt
@@ -164,7 +164,8 @@ RequiredBundle tag that adds another bundle by name, e.g.:
 The dependent bundle is added to the list of bundles sent to the
 client, *not* to the parent bundle itself. If you want to propagate
 the modification flag from the required bundle, you can add
-``modification="inherit"`` to the RequiredBundle tag. An example:
+``inherit_modification="true"`` to the RequiredBundle tag.
+An example:
 
 ``nfs-client.xml``:
 
@@ -193,13 +194,13 @@ the modification flag from the required bundle, you can add
 
 If a new ``nfs-utils`` package was installed, the ``nfslock``,
 ``rpcbind``, and ``nfs`` services would be restarted, but *not* the
-``autofs`` service. If you would add ``modification="inherit`` to
-the RequiredBundle tag, you would ensure the propagation of the
+``autofs`` service. If you would add ``inherit_modification="true"``
+to the RequiredBundle tag, you would ensure the propagation of the
 modification flag and the ``autofs`` service would be restarted,
 too. But if a new ``/etc/auto.misc`` file was sent out, *only* the
 ``autofs`` service would be restarted, but the ``nfslock``,
 ``rpcbind``, and ``nfs`` services would not be restarted
-(independent of the ``modification`` flag).
+(independent of the ``inherit_modification`` flag).
 
 Altsrc
 ======

--- a/schemas/bundle.xsd
+++ b/schemas/bundle.xsd
@@ -307,13 +307,6 @@
     <xsd:attributeGroup ref="py:genshiAttrs"/>
   </xsd:complexType>
 
-  <xsd:simpleType name='ModificationTypeEnum'>
-    <xsd:restriction base="xsd:string">
-      <xsd:enumeration value="ignore"/>
-      <xsd:enumeration value="inherit"/>
-    </xsd:restriction>
-  </xsd:simpleType>
-
   <xsd:complexType name='RequiredBundleType'>
     <xsd:attribute type='xsd:string' name='name' use='required'>
       <xsd:annotation>
@@ -322,7 +315,7 @@
         </xsd:documentation>
       </xsd:annotation>
     </xsd:attribute>
-    <xsd:attribute type='ModificationTypeEnum' name='modification'>
+    <xsd:attribute type='xsd:boolean' name='inherit_modification'>
       <xsd:annotation>
         <xsd:documentation>
           Specify how to handle modifications in the required

--- a/schemas/bundle.xsd
+++ b/schemas/bundle.xsd
@@ -263,6 +263,13 @@
           </xsd:documentation>
         </xsd:annotation>
       </xsd:element>
+      <xsd:element name='RequiredBundle' type='RequiredBundleType'>
+        <xsd:annotation>
+          <xsd:documentation>
+            Nesting Bundle tags to specify dependencies to other bundles.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
     </xsd:choice>
   </xsd:group>
 
@@ -294,6 +301,35 @@
           within this tag are only used on clients that are not
           members of the group, or that have hostnames that do not
           match.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attributeGroup ref="py:genshiAttrs"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name='ModificationTypeEnum'>
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="ignore"/>
+      <xsd:enumeration value="inherit"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:complexType name='RequiredBundleType'>
+    <xsd:attribute type='xsd:string' name='name' use='required'>
+      <xsd:annotation>
+        <xsd:documentation>
+          The name of the required bundle.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute type='ModificationTypeEnum' name='modification'>
+      <xsd:annotation>
+        <xsd:documentation>
+          Specify how to handle modifications in the required
+          bundle. You can either ignore the modifications (this
+          is the default) or you can inherit the modifications
+          so that Services in the current Bundle are restarted
+          if the required Bundle is modified.
         </xsd:documentation>
       </xsd:annotation>
     </xsd:attribute>

--- a/src/lib/Bcfg2/Client/Tools/BundleDeps.py
+++ b/src/lib/Bcfg2/Client/Tools/BundleDeps.py
@@ -1,0 +1,34 @@
+""" Bundle dependency support """
+
+import Bcfg2.Client.Tools
+
+
+class BundleDeps(Bcfg2.Client.Tools.Tool):
+    """Bundle dependency helper for Bcfg2. It handles Bundle tags inside the
+    bundles that references the required other bundles that should change the
+    modification status if the referenced bundles is modified."""
+
+    name = 'Bundle'
+    __handles__ = [('Bundle', None)]
+    __req__ = {'Bundle': ['name']}
+
+    def InstallBundle(self, _):
+        """Simple no-op because we only need the BundleUpdated hook."""
+        return dict()
+
+    def VerifyBundle(self, entry, _):  # pylint: disable=W0613
+        """Simple no-op because we only need the BundleUpdated hook."""
+        return True
+
+    def BundleUpdated(self, entry):
+        """This handles the dependencies on this bundle. It searches all
+        Bundle tags in other bundles that references the current bundle name
+        and marks those tags as modified to trigger the modification hook on
+        the other bundles."""
+
+        bundle_name = entry.get('name')
+        for bundle in self.config.findall('./Bundle/Bundle'):
+            if bundle.get('name') == bundle_name and \
+               bundle not in self.modified:
+                self.modified.append(bundle)
+        return dict()

--- a/src/lib/Bcfg2/Server/Plugins/Bundler.py
+++ b/src/lib/Bcfg2/Server/Plugins/Bundler.py
@@ -8,6 +8,7 @@ import fnmatch
 import lxml.etree
 from Bcfg2.Server.Plugin import StructFile, Plugin, Structure, \
     StructureValidator, XMLDirectoryBacked, Generator
+from Bcfg2.version import Bcfg2VersionInfo
 from genshi.template import TemplateError
 
 
@@ -116,17 +117,35 @@ class Bundler(Plugin,
                     for el in child.getchildren():
                         data.append(el)
                     data.remove(child)
-                elif child.get("name"):
+                else:
+                    # no children -- wat
+                    self.logger.warning("Bundler: Useless empty Bundle tag "
+                                        "in %s" % self.name)
+                    data.remove(child)
+
+            for child in data.findall('RequiredBundle'):
+                if child.get("name"):
                     # dependent bundle -- add it to the list of
                     # bundles for this client
                     if child.get("name") not in bundles_added:
                         bundles.append(child.get("name"))
                         bundles_added.add(child.get("name"))
+                    if child.get('modification', 'ignore') == 'inherit':
+                        if metadata.version_info >= \
+                           Bcfg2VersionInfo('1.4.0pre2'):
+                            lxml.etree.SubElement(data, 'Bundle',
+                                                  name=child.get('name'))
+                        else:
+                            self.logger.warning(
+                                'Bundler: modification="inherit" is only '
+                                'supported for clients starting 1.4.0pre2')
                     data.remove(child)
                 else:
-                    # neither name or children -- wat
-                    self.logger.warning("Bundler: Useless empty Bundle tag "
-                                        "in %s" % self.name)
+                    # no name -- wat
+                    self.logger.warning('Bundler: Missing required name in '
+                                        'RequiredBundle tag in %s' %
+                                        self.name)
                     data.remove(child)
+
             bundleset.append(data)
         return bundleset

--- a/src/lib/Bcfg2/Server/Plugins/Bundler.py
+++ b/src/lib/Bcfg2/Server/Plugins/Bundler.py
@@ -130,15 +130,16 @@ class Bundler(Plugin,
                     if child.get("name") not in bundles_added:
                         bundles.append(child.get("name"))
                         bundles_added.add(child.get("name"))
-                    if child.get('modification', 'ignore') == 'inherit':
+                    if child.get('inherit_modification', 'false') == 'true':
                         if metadata.version_info >= \
                            Bcfg2VersionInfo('1.4.0pre2'):
                             lxml.etree.SubElement(data, 'Bundle',
                                                   name=child.get('name'))
                         else:
                             self.logger.warning(
-                                'Bundler: modification="inherit" is only '
-                                'supported for clients starting 1.4.0pre2')
+                                'Bundler: inherit_modification="true" is '
+                                'only supported for clients starting '
+                                '1.4.0pre2')
                     data.remove(child)
                 else:
                     # no name -- wat

--- a/testsuite/Testsrc/Testlib/TestServer/TestPlugins/TestBundler.py
+++ b/testsuite/Testsrc/Testlib/TestServer/TestPlugins/TestBundler.py
@@ -77,7 +77,7 @@ class TestBundler(TestPlugin, TestStructure, TestXMLDirectoryBacked):
         has_dep = lxml.etree.Element("Bundle")
         lxml.etree.SubElement(has_dep, "RequiredBundle", name="is_dep")
         lxml.etree.SubElement(has_dep, "RequiredBundle", name="is_mod_dep",
-                              modification="inherit")
+                              inherit_modification="true")
         lxml.etree.SubElement(has_dep, "Package", name="foo")
         b.bundles['has_dep'].XMLMatch.return_value = has_dep
         expected['has_dep'] = lxml.etree.Element("Bundle", name="has_dep")
@@ -124,7 +124,7 @@ class TestBundler(TestPlugin, TestStructure, TestXMLDirectoryBacked):
         has_dep = lxml.etree.Element("Bundle")
         lxml.etree.SubElement(has_dep, "RequiredBundle", name="is_dep")
         lxml.etree.SubElement(has_dep, "RequiredBundle", name="is_mod_dep",
-                              modification="inherit")
+                              inherit_modification="true")
         lxml.etree.SubElement(has_dep, "Package", name="foo")
         b.bundles['has_dep'].XMLMatch.return_value = has_dep
         expected['has_dep'] = lxml.etree.Element("Bundle", name="has_dep")

--- a/testsuite/Testsrc/Testlib/TestServer/TestPlugins/TestBundler.py
+++ b/testsuite/Testsrc/Testlib/TestServer/TestPlugins/TestBundler.py
@@ -74,7 +74,7 @@ class TestBundler(TestPlugin, TestStructure, TestXMLDirectoryBacked):
         lxml.etree.SubElement(expected['xinclude'], "Path", name="/test")
 
         has_dep = lxml.etree.Element("Bundle")
-        lxml.etree.SubElement(has_dep, "Bundle", name="is_dep")
+        lxml.etree.SubElement(has_dep, "RequiredBundle", name="is_dep")
         lxml.etree.SubElement(has_dep, "Package", name="foo")
         b.bundles['has_dep'].XMLMatch.return_value = has_dep
         expected['has_dep'] = lxml.etree.Element("Bundle", name="has_dep")


### PR DESCRIPTION
Bundle dependencies are now realized with RequiredBundle and support inheritance of the modification flag. This requires new client support and will only work with clients >= 1.4.0pre2.

The new tag name is required for validation. The tag name and type association in the schema has to be unambiguous and we need nested bundle tags for xincludes. Bundle dependency are only available in 1.4.0pre1, so I do not know if we need a migration script that renames the empty bundle tags to RequiredBundle.