### PR TITLE
Bcfg2/Options/Parser: fix --version option, add test

### DIFF
--- a/src/lib/Bcfg2/Options/Parser.py
+++ b/src/lib/Bcfg2/Options/Parser.py
@@ -6,7 +6,7 @@ import sys
 
 from Bcfg2.version import __version__
 from Bcfg2.Compat import ConfigParser
-from Bcfg2.Options import Option, PathOption, BooleanOption, _debug
+from Bcfg2.Options import Option, PathOption, _debug
 
 __all__ = ["setup", "OptionParserException", "Parser", "get_parser",
            "new_parser"]
@@ -43,9 +43,16 @@ class Parser(argparse.ArgumentParser):
                             help="Path to configuration file",
                             default="/etc/bcfg2.conf")
 
+    #: Verbose version string that is printed if executed with --version
+    _version_string = "%s %s on Python %s" % (
+        os.path.basename(sys.argv[0]),
+        __version__,
+        ".".join(str(v) for v in sys.version_info[0:3]))
+
     #: Builtin options that apply to all commands
     options = [configfile,
-               BooleanOption('--version', help="Print the version and exit"),
+               Option('--version', help="Print the version and exit",
+                      action="version", version=_version_string),
                Option('-E', '--encoding', metavar='<encoding>',
                       default='UTF-8', help="Encoding of config files",
                       cf=('components', 'encoding'))]

--- a/testsuite/Testsrc/Testlib/TestOptions/TestOptions.py
+++ b/testsuite/Testsrc/Testlib/TestOptions/TestOptions.py
@@ -185,6 +185,13 @@ class TestBasicOptions(OptionTestCase):
         options = self._test_options(env={"TEST_PATH_OPTION": "/foo"})
         self.assertEqual(options.test_path_option, "/foo")
 
+    def test_version(self):
+        """print version and exit on --version"""
+        self.assertRaises(
+            SystemExit,
+            self._test_options,
+            options=['--version'])
+
     def test_set_boolean_in_cli(self):
         """set boolean options in CLI options."""
         # passing the option yields the reverse of the default, no


### PR DESCRIPTION
This fixes the `--version` option (it prints the same text like the 1.3.x versions) and add a test to ensure, that the `--version` option is parsed and the execution is aborted with SystemExit.
