### PR TITLE
Bcfg2/Server/Admin: fix the Help subcommand

### DIFF
--- a/src/lib/Bcfg2/Server/Admin.py
+++ b/src/lib/Bcfg2/Server/Admin.py
@@ -1198,7 +1198,9 @@ class CLI(Bcfg2.Options.CommandRegistry):
     def run(self):
         """ Run bcfg2-admin """
         try:
-            self.commands[Bcfg2.Options.setup.subcommand].setup()
+            cmd = self.commands[Bcfg2.Options.setup.subcommand]
+            if hasattr(cmd, 'setup'):
+                cmd.setup()
             return self.runcommand()
         finally:
             self.shutdown()


### PR DESCRIPTION
At least the Help subcommand does not provide a setup method. So we need to
exclude if from the setup() call.
