### PR TITLE
Remove blanket excepts from plugins and lint

### DIFF
--- a/src/lib/Bcfg2/Server/Lint/GroupPatterns.py
+++ b/src/lib/Bcfg2/Server/Lint/GroupPatterns.py
@@ -4,7 +4,8 @@
 import sys
 
 from Bcfg2.Server.Lint import ServerPlugin
-from Bcfg2.Server.Plugins.GroupPatterns import PatternMap
+from Bcfg2.Server.Plugins.GroupPatterns import PatternMap, \
+    PatternInitializationError
 
 
 class GroupPatterns(ServerPlugin):
@@ -36,7 +37,7 @@ class GroupPatterns(ServerPlugin):
                     PatternMap(pat, None, groups)
                 else:
                     PatternMap(None, pat, groups)
-            except:  # pylint: disable=W0702
+            except PatternInitializationError:
                 err = sys.exc_info()[1]
                 self.LintError("pattern-fails-to-initialize",
                                "Failed to initialize %s %s for %s: %s" %

--- a/src/lib/Bcfg2/Server/Lint/__init__.py
+++ b/src/lib/Bcfg2/Server/Lint/__init__.py
@@ -26,7 +26,7 @@ def _ioctl_GWINSZ(fd):  # pylint: disable=C0103
     from the given file descriptor """
     try:
         return struct.unpack('hh', fcntl.ioctl(fd, termios.TIOCGWINSZ, '1234'))
-    except:  # pylint: disable=W0702
+    except (IOError, struct.error):
         return None
 
 
@@ -40,7 +40,7 @@ def get_termsize():
             fd = os.open(os.ctermid(), os.O_RDONLY)
             dims = _ioctl_GWINSZ(fd)
             os.close(fd)
-        except:  # pylint: disable=W0702
+        except IOError:
             pass
     if not dims:
         try:

--- a/src/lib/Bcfg2/Server/Plugin/helpers.py
+++ b/src/lib/Bcfg2/Server/Plugin/helpers.py
@@ -266,7 +266,7 @@ class FileBacked(Debuggable):
         self.fam = Bcfg2.Server.FileMonitor.get_fam()
 
     def HandleEvent(self, event=None):
-        """ HandleEvent is called whenever the FAM registers an event.
+        """HandleEvent is called whenever the FAM registers an event.
 
         :param event: The event object
         :type event: Bcfg2.Server.FileMonitor.Event
@@ -276,13 +276,11 @@ class FileBacked(Debuggable):
             return
         try:
             self.data = open(self.name).read()
-            self.Index()
         except IOError:
             err = sys.exc_info()[1]
             self.logger.error("Failed to read file %s: %s" % (self.name, err))
-        except:
-            err = sys.exc_info()[1]
-            self.logger.error("Failed to parse file %s: %s" % (self.name, err))
+
+        self.Index()
 
     def Index(self):
         """ Index() is called by :func:`HandleEvent` every time the
@@ -1196,7 +1194,7 @@ class SpecificData(Debuggable):
             self.data = open(self.name).read()
         except UnicodeDecodeError:
             self.data = open(self.name, mode='rb').read()
-        except:  # pylint: disable=W0201
+        except IOError:
             self.logger.error("Failed to read file %s" % self.name)
 
 

--- a/src/lib/Bcfg2/Server/Plugin/interfaces.py
+++ b/src/lib/Bcfg2/Server/Plugin/interfaces.py
@@ -445,8 +445,14 @@ class ThreadedStatistics(Statistics, Threaded, threading.Thread):
             except Empty:
                 continue
             except:
-                err = sys.exc_info()[1]
-                self.logger.error("ThreadedStatistics: %s" % err)
+                # we want to catch all exceptions here so that a stray
+                # error doesn't kill the entire statistics thread. For
+                # instance, if a bad value gets pushed onto the queue
+                # and the assignment above raises TypeError, we want
+                # to report the error, ignore the bad value, and
+                # continue processing statistics.
+                self.logger.error("Unknown error processing statistics: %s" %
+                                  sys.exc_info()[1])
                 continue
             self.handle_statistic(client, xdata)
         if self.work_queue is not None and not self.work_queue.empty():

--- a/src/lib/Bcfg2/Server/Plugins/AWSTags.py
+++ b/src/lib/Bcfg2/Server/Plugins/AWSTags.py
@@ -1,4 +1,4 @@
-""" Query tags from AWS via boto, optionally setting group membership """
+"""Query tags from AWS via boto, optionally setting group membership."""
 
 import os
 import re
@@ -82,22 +82,17 @@ class PatternFile(Bcfg2.Server.Plugin.XMLFileBacked):
                 self.tags.append(AWSTagPattern(entry.get("name"),
                                                entry.get("value"),
                                                groups))
-            except:  # pylint: disable=W0702
+            except re.error:
                 self.logger.error("AWSTags: Failed to initialize pattern %s: "
                                   "%s" % (entry.get("name"),
                                           sys.exc_info()[1]))
 
-    def get_groups(self, hostname, tags):
+    def get_groups(self, tags):
         """ return a list of groups that should be added to the given
-        client based on patterns that match the hostname """
+        client based on patterns that match the tags """
         ret = []
         for pattern in self.tags:
-            try:
-                ret.extend(pattern.get_groups(tags))
-            except:  # pylint: disable=W0702
-                self.logger.error("AWSTags: Failed to process pattern %s for "
-                                  "%s" % (pattern, hostname),
-                                  exc_info=1)
+            ret.extend(pattern.get_groups(tags))
         return ret
 
 
@@ -182,5 +177,4 @@ class AWSTags(Bcfg2.Server.Plugin.Plugin,
         return self.get_tags(metadata)
 
     def get_additional_groups(self, metadata):
-        return self.config.get_groups(metadata.hostname,
-                                      self.get_tags(metadata))
+        return self.config.get_groups(self.get_tags(metadata))

--- a/src/lib/Bcfg2/Server/Plugins/Bundler.py
+++ b/src/lib/Bcfg2/Server/Plugins/Bundler.py
@@ -92,10 +92,6 @@ class Bundler(Plugin,
                 self.logger.error("Bundler: Failed to render templated bundle "
                                   "%s: %s" % (bundlename, err))
                 continue
-            except:
-                self.logger.error("Bundler: Unexpected bundler error for %s" %
-                                  bundlename, exc_info=1)
-                continue
 
             if data.get("independent", "false").lower() == "true":
                 data.tag = "Independent"

--- a/src/lib/Bcfg2/Server/Plugins/Cfg/CfgGenshiGenerator.py
+++ b/src/lib/Bcfg2/Server/Plugins/Cfg/CfgGenshiGenerator.py
@@ -10,6 +10,7 @@ from Bcfg2.Server.Plugin import PluginExecutionError, removecomment, \
     DefaultTemplateDataProvider, get_template_data
 from Bcfg2.Server.Plugins.Cfg import CfgGenerator
 from genshi.template import TemplateLoader, NewTextTemplate
+from genshi.template.base import TemplateError
 from genshi.template.eval import UndefinedError, Suite
 
 
@@ -117,6 +118,8 @@ class CfgGenshiGenerator(CfgGenerator):
                                                 quad[2]))
             raise
         except:
+            # this needs to be a blanket except, since it can catch
+            # any error raised by the genshi template.
             self._handle_genshi_exception(sys.exc_info())
     get_data.__doc__ = CfgGenerator.get_data.__doc__
 
@@ -184,10 +187,10 @@ class CfgGenshiGenerator(CfgGenerator):
     def handle_event(self, event):
         CfgGenerator.handle_event(self, event)
         try:
-            self.template = \
-                self.loader.load(self.name, cls=NewTextTemplate,
-                                 encoding=Bcfg2.Options.setup.encoding)
-        except:
+            self.template = self.loader.load(
+                self.name, cls=NewTextTemplate,
+                encoding=Bcfg2.Options.setup.encoding)
+        except TemplateError:
             raise PluginExecutionError("Failed to load template: %s" %
                                        sys.exc_info()[1])
     handle_event.__doc__ = CfgGenerator.handle_event.__doc__

--- a/src/lib/Bcfg2/Server/Plugins/FileProbes.py
+++ b/src/lib/Bcfg2/Server/Plugins/FileProbes.py
@@ -38,7 +38,7 @@ if not os.path.exists(path):
 
 try:
     stat = os.stat(path)
-except:
+except OSError:
     sys.stderr.write("Could not stat %%s: %%s" %% (path, sys.exc_info()[1]))
     raise SystemExit(0)
 data = Bcfg2.Client.XML.Element("ProbedFileData",
@@ -48,7 +48,7 @@ data = Bcfg2.Client.XML.Element("ProbedFileData",
                                 mode=oct_mode(stat[0] & 4095))
 try:
     data.text = b64encode(open(path).read())
-except:
+except IOError:
     sys.stderr.write("Could not read %%s: %%s" %% (path, sys.exc_info()[1]))
     raise SystemExit(0)
 print(Bcfg2.Client.XML.tostring(data, xml_declaration=False).decode('UTF-8'))

--- a/src/lib/Bcfg2/Server/Plugins/Git.py
+++ b/src/lib/Bcfg2/Server/Plugins/Git.py
@@ -41,22 +41,17 @@ class Git(Version):
 
     def get_revision(self):
         """Read git revision information for the Bcfg2 repository."""
-        try:
-            if HAS_GITPYTHON:
-                return self.repo.head.commit.hexsha
-            else:
-                cmd = ["git", "--git-dir", self.vcs_path,
-                       "--work-tree", Bcfg2.Options.setup.vcs_root,
-                       "rev-parse", "HEAD"]
-                self.debug_log("Git: Running %s" % cmd)
-                result = self.cmd.run(cmd)
-                if not result.success:
-                    raise Exception(result.stderr)
-                return result.stdout
-        except:
-            raise PluginExecutionError("Git: Error getting revision from %s: "
-                                       "%s" % (Bcfg2.Options.setup.vcs_root,
-                                               sys.exc_info()[1]))
+        if HAS_GITPYTHON:
+            return self.repo.head.commit.hexsha
+        else:
+            cmd = ["git", "--git-dir", self.vcs_path,
+                   "--work-tree", Bcfg2.Options.setup.vcs_root,
+                   "rev-parse", "HEAD"]
+            self.debug_log("Git: Running %s" % cmd)
+            result = self.cmd.run(cmd)
+            if not result.success:
+                raise PluginExecutionError(result.stderr)
+            return result.stdout
 
     def Update(self, ref=None):
         """ Git.Update() => True|False

--- a/src/lib/Bcfg2/Server/Plugins/Guppy.py
+++ b/src/lib/Bcfg2/Server/Plugins/Guppy.py
@@ -1,9 +1,9 @@
-"""
-This plugin is used to trace memory leaks within the bcfg2-server
-process using Guppy.  By default the remote debugger is started
-when this plugin is enabled.  The debugger can be shutoff in a running
-process using "bcfg2-admin xcmd Guppy.Disable" and reenabled using
-"bcfg2-admin xcmd Guppy.Enable".
+"""Debugging plugin to trace memory leaks within the bcfg2-server process.
+
+By default the remote debugger is started when this plugin is enabled.
+The debugger can be shutoff in a running process using "bcfg2-admin
+xcmd Guppy.Disable" and reenabled using "bcfg2-admin xcmd
+Guppy.Enable".
 
 To attach the console run:
 
@@ -23,36 +23,27 @@ Remote connection 1. To return to Monitor, type <Ctrl-C> or .<RETURN>
 Remote interactive console. To return to Annex, type '-'.
 >>> hp.heap()
 ...
-
-
 """
 import Bcfg2.Server.Plugin
 from guppy.heapy import Remote
 
 
 class Guppy(Bcfg2.Server.Plugin.Plugin):
-    """Guppy is a debugging plugin to help trace memory leaks"""
+    """Guppy is a debugging plugin to help trace memory leaks."""
     __author__ = 'bcfg-dev@mcs.anl.gov'
     __rmi__ = Bcfg2.Server.Plugin.Plugin.__rmi__ + ['Enable', 'Disable']
     __child_rmi__ = __rmi__[:]
 
     def __init__(self, core):
         Bcfg2.Server.Plugin.Plugin.__init__(self, core)
-
         self.Enable()
 
-    def Enable(self):
-        """Enable remote debugging"""
-        try:
-            Remote.on()
-        except:
-            self.logger.error("Failed to create Heapy context")
-            raise Bcfg2.Server.Plugin.PluginInitError
+    @staticmethod
+    def Enable():
+        """Enable remote debugging."""
+        Remote.on()
 
-    def Disable(self):
-        """Disable remote debugging"""
-        try:
-            Remote.off()
-        except:
-            self.logger.error("Failed to disable Heapy")
-            raise Bcfg2.Server.Plugin.PluginInitError
+    @staticmethod
+    def Disable():
+        """Disable remote debugging."""
+        Remote.off()

--- a/src/lib/Bcfg2/Server/Plugins/Hg.py
+++ b/src/lib/Bcfg2/Server/Plugins/Hg.py
@@ -1,5 +1,5 @@
-""" The Hg plugin provides a revision interface for Bcfg2 repos using
-mercurial. """
+"""Revision interface for Bcfg2 repos using mercurial.
+"""
 
 import sys
 from mercurial import ui, hg
@@ -7,8 +7,9 @@ import Bcfg2.Server.Plugin
 
 
 class Hg(Bcfg2.Server.Plugin.Version):
-    """ The Hg plugin provides a revision interface for Bcfg2 repos
-    using mercurial. """
+    """Revision interface for Bcfg2 repos using mercurial.
+    """
+
     __author__ = 'bcfg-dev@mcs.anl.gov'
     __vcs_metadata_path__ = ".hg"
 
@@ -24,7 +25,7 @@ class Hg(Bcfg2.Server.Plugin.Version):
             repo = hg.repository(ui.ui(), repo_path)
             tip = repo.changelog.tip()
             return repo.changelog.rev(tip)
-        except:
+        except hg.error.RepoError:
             err = sys.exc_info()[1]
             msg = "Failed to read hg repository: %s" % err
             self.logger.error(msg)

--- a/src/lib/Bcfg2/Server/Plugins/Ohai.py
+++ b/src/lib/Bcfg2/Server/Plugins/Ohai.py
@@ -51,7 +51,7 @@ class OhaiCache(object):
         if item not in self.cache:
             try:
                 data = open(self.hostpath(item)).read()
-            except:
+            except IOError:
                 raise KeyError(item)
             self.cache[item] = json.loads(data)
         return self.cache[item]
@@ -61,7 +61,7 @@ class OhaiCache(object):
             del self.cache[item]
         try:
             os.unlink(self.hostpath(item))
-        except:
+        except OSError:
             raise IndexError("Could not unlink %s: %s" % (self.hostpath(item),
                                                           sys.exc_info()[1]))
 

--- a/src/lib/Bcfg2/Server/Plugins/Packages/Apt.py
+++ b/src/lib/Bcfg2/Server/Plugins/Packages/Apt.py
@@ -89,7 +89,7 @@ class AptSource(Source):
                 bprov[barch] = dict()
             try:
                 reader = gzip.GzipFile(fname)
-            except:
+            except IOError:
                 self.logger.error("Packages: Failed to read file %s" % fname)
                 raise
             for line in reader.readlines():

--- a/src/lib/Bcfg2/Server/Plugins/Packages/Pac.py
+++ b/src/lib/Bcfg2/Server/Plugins/Packages/Pac.py
@@ -67,7 +67,7 @@ class PacSource(Source):
             try:
                 self.debug_log("Packages: try to read %s" % fname)
                 tar = tarfile.open(fname, "r")
-            except:
+            except (IOError, tarfile.TarError):
                 self.logger.error("Packages: Failed to read file %s" % fname)
                 raise
 

--- a/src/lib/Bcfg2/Server/Plugins/Packages/Pkgng.py
+++ b/src/lib/Bcfg2/Server/Plugins/Packages/Pkgng.py
@@ -71,7 +71,7 @@ class PkgngSource(Source):
             try:
                 tar = tarfile.open(fileobj=lzma.LZMAFile(fname))
                 reader = tar.extractfile('packagesite.yaml')
-            except:
+            except (IOError, tarfile.TarError):
                 self.logger.error("Packages: Failed to read file %s" % fname)
                 raise
             for line in reader.readlines():

--- a/src/lib/Bcfg2/Server/Plugins/Packages/Source.py
+++ b/src/lib/Bcfg2/Server/Plugins/Packages/Source.py
@@ -331,10 +331,11 @@ class Source(Debuggable):  # pylint: disable=R0902
 
     @track_statistics()
     def setup_data(self, force_update=False):
-        """ Perform all data fetching and setup tasks.  For most
-        backends, this involves downloading all metadata from the
-        repository, parsing it, and caching the parsed data locally.
-        The order of operations is:
+        """Perform all data fetching and setup tasks.
+
+        For most backends, this involves downloading all metadata from
+        the repository, parsing it, and caching the parsed data
+        locally.  The order of operations is:
 
         #. Call :func:`load_state` to try to load data from the local
            cache.
@@ -352,6 +353,15 @@ class Source(Debuggable):  # pylint: disable=R0902
                              upstream repository.
         :type force_update: bool
         """
+        # there are a bunch of wildcard except statements here,
+        # because the various functions called herein (``load_state``,
+        # ``read_files``, ``update``) are defined entirely by the
+        # Packages plugins that implement them.
+        #
+        # TODO: we should define an exception subclass that each of
+        # these functions can raise when an *expected* error condition
+        # is encountered.
+        #
         # pylint: disable=W0702
         if not force_update:
             if os.path.exists(self.cachefile):

--- a/src/lib/Bcfg2/Server/Plugins/Packages/Yum.py
+++ b/src/lib/Bcfg2/Server/Plugins/Packages/Yum.py
@@ -631,10 +631,6 @@ class YumCollection(Collection):
             err = sys.exc_info()[1]
             self.logger.error("Packages: Could not contact Pulp server: %s" %
                               err)
-        except:
-            err = sys.exc_info()[1]
-            self.logger.error("Packages: Unknown error querying Pulp server: "
-                              "%s" % err)
         return consumer
 
     @track_statistics()
@@ -1034,10 +1030,6 @@ class YumSource(Source):
                 err = sys.exc_info()[1]
                 raise SourceInitError("Could not contact Pulp server: %s" %
                                       err)
-            except:
-                err = sys.exc_info()[1]
-                raise SourceInitError("Unknown error querying Pulp server: %s"
-                                      % err)
             self.rawurl = "%s/%s" % (PULPCONFIG.cds['baseurl'],
                                      self.repo['relative_path'])
             self.arches = [self.repo['arch']]

--- a/src/lib/Bcfg2/Server/Plugins/Packages/YumHelper.py
+++ b/src/lib/Bcfg2/Server/Plugins/Packages/YumHelper.py
@@ -285,8 +285,8 @@ class HelperSubcommand(Bcfg2.Options.Subcommand):
     def run(self, setup):
         try:
             data = json.loads(sys.stdin.read())
-        except:  # pylint: disable=W0702
-            self.logger.error("Unexpected error decoding JSON input: %s" %
+        except ValueError:
+            self.logger.error("Error decoding JSON input: %s" %
                               sys.exc_info()[1])
             print(json.dumps(self.fallback))
             return 2

--- a/src/lib/Bcfg2/Server/Plugins/Packages/__init__.py
+++ b/src/lib/Bcfg2/Server/Plugins/Packages/__init__.py
@@ -515,10 +515,6 @@ class Packages(Bcfg2.Server.Plugin.Plugin,
                         err = sys.exc_info()[1]
                         self.logger.error("Packages: Error writing %s to %s: "
                                           "%s" % (key, localfile, err))
-                    except:
-                        err = sys.exc_info()[1]
-                        self.logger.error("Packages: Unknown error fetching "
-                                          "%s: %s" % (key, err))
 
         for kfile in glob.glob(os.path.join(self.keypath, "*")):
             if kfile not in keyfiles:

--- a/src/lib/Bcfg2/Server/Plugins/Pkgmgr.py
+++ b/src/lib/Bcfg2/Server/Plugins/Pkgmgr.py
@@ -35,7 +35,7 @@ class FuzzyDict(dict):
     def get(self, key, default=None):
         try:
             return self.__getitem__(key)
-        except:
+        except KeyError:
             if default:
                 return default
             raise
@@ -182,11 +182,7 @@ class PNode(object):
         """Return a dictionary of package mappings."""
         if self.predicate(metadata, entry):
             for key in self.contents:
-                try:
-                    data[key].update(self.contents[key])
-                except:  # pylint: disable=W0702
-                    data[key] = FuzzyDict()
-                    data[key].update(self.contents[key])
+                data.setdefault(key, FuzzyDict).update(self.contents[key])
             for child in self.children:
                 child.Match(metadata, data)
 

--- a/src/lib/Bcfg2/Server/Plugins/Probes.py
+++ b/src/lib/Bcfg2/Server/Plugins/Probes.py
@@ -405,7 +405,7 @@ class ProbeSet(Bcfg2.Server.Plugin.EntrySet):
             else:
                 try:
                     probe.text = entry.data
-                except:  # pylint: disable=W0702
+                except ValueError:
                     self.logger.error("Client unable to handle unicode "
                                       "probes. Skipping %s" %
                                       probe.get('name'))
@@ -447,12 +447,7 @@ class Probes(Bcfg2.Server.Plugin.Probing,
         Bcfg2.Server.Plugin.Connector.__init__(self)
         Bcfg2.Server.Plugin.DatabaseBacked.__init__(self, core)
 
-        try:
-            self.probes = ProbeSet(self.data, self.name)
-        except:
-            err = sys.exc_info()[1]
-            raise Bcfg2.Server.Plugin.PluginInitError(err)
-
+        self.probes = ProbeSet(self.data, self.name)
         if self._use_db:
             self.probestore = DBProbeStore(core, self.data)
         else:

--- a/src/lib/Bcfg2/Server/Plugins/Properties.py
+++ b/src/lib/Bcfg2/Server/Plugins/Properties.py
@@ -79,13 +79,12 @@ class PropertyFile(object):
 
 
 class JSONPropertyFile(Bcfg2.Server.Plugin.FileBacked, PropertyFile):
-    """ Handle JSON Properties files. """
+    """Handle JSON Properties files."""
 
     def __init__(self, name):
         Bcfg2.Server.Plugin.FileBacked.__init__(self, name)
         PropertyFile.__init__(self, name)
         self.json = None
-    __init__.__doc__ = Bcfg2.Server.Plugin.FileBacked.__init__.__doc__
 
     def Index(self):
         try:
@@ -94,21 +93,18 @@ class JSONPropertyFile(Bcfg2.Server.Plugin.FileBacked, PropertyFile):
             err = sys.exc_info()[1]
             raise PluginExecutionError("Could not load JSON data from %s: %s" %
                                        (self.name, err))
-    Index.__doc__ = Bcfg2.Server.Plugin.FileBacked.Index.__doc__
 
     def _write(self):
         json.dump(self.json, open(self.name, 'wb'))
         return True
-    _write.__doc__ = PropertyFile._write.__doc__
 
     def validate_data(self):
         try:
             json.dumps(self.json)
-        except:
+        except TypeError:
             err = sys.exc_info()[1]
             raise PluginExecutionError("Data for %s cannot be dumped to JSON: "
                                        "%s" % (self.name, err))
-    validate_data.__doc__ = PropertyFile.validate_data.__doc__
 
     def __str__(self):
         return str(self.json)

--- a/src/lib/Bcfg2/Server/Plugins/Reporting.py
+++ b/src/lib/Bcfg2/Server/Plugins/Reporting.py
@@ -3,7 +3,6 @@
 import sys
 import time
 import platform
-import traceback
 import lxml.etree
 import Bcfg2.Options
 from Bcfg2.Reporting.Transport.base import TransportError
@@ -102,11 +101,11 @@ class Reporting(Statistics, Threaded, PullSource):
             except TransportError:
                 continue
             except:
-                self.logger.error("%s: Attempt %s: Failed to add statistic %s"
+                self.logger.error("%s: Attempt %s: Failed to add statistic: %s"
                                   % (self.__class__.__name__, i,
-                                     traceback.format_exc().splitlines()[-1]))
-        self.logger.error("%s: Retry limit reached for %s" %
-                          (self.__class__.__name__, client.hostname))
+                                     sys.exc_info()[1]))
+        raise PluginExecutionError("%s: Retry limit reached for %s" %
+                                   (self.__class__.__name__, client.hostname))
 
     def shutdown(self):
         super(Reporting, self).shutdown()

--- a/src/lib/Bcfg2/Server/Plugins/SSHbase.py
+++ b/src/lib/Bcfg2/Server/Plugins/SSHbase.py
@@ -199,20 +199,19 @@ class SSHbase(Bcfg2.Server.Plugin.Plugin,
                     newnames.add(name.split('.')[0])
                     try:
                         newips.update(self.get_ipcache_entry(name)[0])
-                    except:  # pylint: disable=W0702
+                    except PluginExecutionError:
                         continue
                 names[cmeta.hostname].update(newnames)
                 names[cmeta.hostname].update(cmeta.addresses)
                 names[cmeta.hostname].update(newips)
                 # TODO: Only perform reverse lookups on IPs if an
                 # option is set.
-                if True:
-                    for ip in newips:
-                        try:
-                            names[cmeta.hostname].update(
-                                self.get_namecache_entry(ip))
-                        except:  # pylint: disable=W0702
-                            continue
+                for ip in newips:
+                    try:
+                        names[cmeta.hostname].update(
+                            self.get_namecache_entry(ip))
+                    except socket.gaierror:
+                        continue
                 names[cmeta.hostname] = sorted(names[cmeta.hostname])
 
             pubkeys = [pubk for pubk in list(self.entries.keys())
@@ -309,7 +308,7 @@ class SSHbase(Bcfg2.Server.Plugin.Plugin,
                          (event.filename, action))
 
     def get_ipcache_entry(self, client):
-        """ Build a cache of dns results. """
+        """Build a cache of dns results."""
         if client in self.ipcache:
             if self.ipcache[client]:
                 return self.ipcache[client]

--- a/src/lib/Bcfg2/Server/Plugins/TemplateHelper.py
+++ b/src/lib/Bcfg2/Server/Plugins/TemplateHelper.py
@@ -55,6 +55,10 @@ class HelperModule(Debuggable):
             module = imp.load_source(safe_module_name(self._module_name),
                                      self.name)
         except:  # pylint: disable=W0702
+            # this needs to be a blanket except because the
+            # imp.load_source() call can raise literally any error,
+            # since it imports the module and just passes through any
+            # exceptions raised.
             err = sys.exc_info()[1]
             self.logger.error("TemplateHelper: Failed to import %s: %s" %
                               (self.name, err))

--- a/testsuite/Testsrc/Testlib/TestServer/TestPlugins/TestCfg/TestCfgGenshiGenerator.py
+++ b/testsuite/Testsrc/Testlib/TestServer/TestPlugins/TestCfg/TestCfgGenshiGenerator.py
@@ -129,7 +129,7 @@ class TestCfgGenshiGenerator(TestCfgGenerator):
             encoding=Bcfg2.Options.setup.encoding)
 
         cgg.loader.reset_mock()
-        cgg.loader.load.side_effect = OSError
+        cgg.loader.load.side_effect = TemplateError("test")
         self.assertRaises(PluginExecutionError,
                           cgg.handle_event, event)
         cgg.loader.load.assert_called_with(

--- a/testsuite/Testsrc/Testlib/TestServer/TestPlugins/TestCfg/Test_init.py
+++ b/testsuite/Testsrc/Testlib/TestServer/TestPlugins/TestCfg/Test_init.py
@@ -726,7 +726,7 @@ class TestCfgEntrySet(TestEntrySet):
 
         # test failure to create data
         reset()
-        creator.create_data.side_effect = OSError
+        creator.create_data.side_effect = CfgCreationError
         self.assertRaises(PluginExecutionError,
                           eset._create_data, entry, metadata)
 

--- a/testsuite/Testsrc/Testlib/TestServer/TestPlugins/TestMetadata.py
+++ b/testsuite/Testsrc/Testlib/TestServer/TestPlugins/TestMetadata.py
@@ -519,13 +519,6 @@ class TestMetadata(_TestMetadata, TestClientRunHooks, TestDatabaseBacked):
             os.path.join(metadata.data, "clients.xml"),
             metadata)
 
-        mock_get_fam.reset_mock()
-        fam = Mock()
-        fam.AddMonitor = Mock(side_effect=IOError)
-        mock_get_fam.return_value = fam
-        self.assertRaises(Bcfg2.Server.Plugin.PluginInitError,
-                          self.get_obj, core=core)
-
     @patch('os.makedirs', Mock())
     @patch('%s.open' % builtins)
     def test_init_repo(self, mock_open):

--- a/testsuite/Testsrc/Testlib/TestServer/TestPlugins/TestProperties.py
+++ b/testsuite/Testsrc/Testlib/TestServer/TestPlugins/TestProperties.py
@@ -124,7 +124,7 @@ class TestJSONPropertyFile(TestFileBacked, TestPropertyFile):
         mock_dumps.assert_called_with(pf.json)
 
         mock_dumps.reset_mock()
-        mock_dumps.side_effect = ValueError
+        mock_dumps.side_effect = TypeError
         self.assertRaises(PluginExecutionError, pf.validate_data)
         mock_dumps.assert_called_with(pf.json)
 

--- a/testsuite/Testsrc/test_code_checks.py
+++ b/testsuite/Testsrc/test_code_checks.py
@@ -49,7 +49,10 @@ contingent_checks = {
                                   ["CfgEncryptedCheetahGenerator.py"]},
     ("M2Crypto", "jinja2"): {"lib/Bcfg2/Server/Plugins/Cfg":
                                   ["CfgEncryptedJinja2Generator.py"]},
-    }
+    ("mercurial",): {"lib/Bcfg2/Server/Plugins": ["Hg.py"]},
+    ("guppy",): {"lib/Bcfg2/Server/Plugins": ["Guppy.py"]},
+    ("boto",): {"lib/Bcfg2/Server/Plugins": ["AWSTags.py"]},
+}
 
 # perform only error checking on the listed files
 error_checks = {

--- a/testsuite/install.sh
+++ b/testsuite/install.sh
@@ -17,7 +17,7 @@ if [[ "$WITH_OPTIONAL_DEPS" == "yes" ]]; then
     sudo apt-get install -y yum libaugeas0 augeas-lenses libacl1-dev libssl-dev
 
     pip install --use-mirrors PyYAML pyinotify boto pylibacl 'django<1.5' \
-        Jinja2
+        Jinja2 mercurial guppy
     easy_install https://fedorahosted.org/released/python-augeas/python-augeas-0.4.1.tar.gz
     if [[ ${PYVER:0:1} == "2" ]]; then
         # django supports py3k, but South doesn't, and the django bits


### PR DESCRIPTION
This removes most blanket except: clauses from all plugins, including
the base plugin libraries, and bcfg2-lint. The few that remain should
all be necessary.

Most of the changes were quite minor, but this did require some
restructuring of the CfgPrivateKeyCreator; as a result, the tests for
that module were rewritten.

This partially fixes #249.