### PR TITLE
Server/Core: semi-automatically handle list args with rmi

### DIFF
--- a/src/lib/Bcfg2/Server/Core.py
+++ b/src/lib/Bcfg2/Server/Core.py
@@ -22,6 +22,7 @@ from Bcfg2.Server.Cache import Cache
 from Bcfg2.Compat import xmlrpclib, wraps  # pylint: disable=W0622
 from Bcfg2.Server.Plugin.exceptions import *  # pylint: disable=W0401,W0614
 from Bcfg2.Server.Plugin.interfaces import *  # pylint: disable=W0401,W0614
+from Bcfg2.Server.Plugin.helpers import handle_rmi_list_argument
 from Bcfg2.Server.Plugin import track_statistics
 
 try:
@@ -1035,7 +1036,8 @@ class Core(object):
         rmi = dict()
         for pname, pinst in self._get_rmi_objects().items():
             for mname in pinst.__rmi__:
-                rmi["%s.%s" % (pname, mname)] = getattr(pinst, mname)
+                func = getattr(pinst, mname)
+                rmi["%s.%s" % (pname, mname)] = handle_rmi_list_argument(func)
         return rmi
 
     def _resolve_exposed_method(self, method_name):

--- a/src/lib/Bcfg2/Server/Plugin/helpers.py
+++ b/src/lib/Bcfg2/Server/Plugin/helpers.py
@@ -70,6 +70,30 @@ class track_statistics(object):  # pylint: disable=C0103
         return inner
 
 
+def rmi_list_argument(func):
+    """ Decorater to mark methods that need one list argument.
+    A RMI call will translate a list of arguments to an argument
+    of one list. """
+    func.list_argument = True
+    return func
+
+
+def handle_rmi_list_argument(func):
+    """ Automatically handle list arguments. For calls that are marked
+    with `rmi_list_argument` the arguments get converted. All other calls
+    are simply passed throught. """
+
+    @wraps(func)
+    def inner(*args):
+        """ Convert a list of arguments to one list argument. """
+        return func(list(args))
+
+    if getattr(func, 'list_argument', False):
+        return inner
+    else:
+        return func
+
+
 def removecomment(stream):
     """ A Genshi filter that removes comments from the stream.  This
     function is a generator.

--- a/src/lib/Bcfg2/Server/Plugins/Metadata.py
+++ b/src/lib/Bcfg2/Server/Plugins/Metadata.py
@@ -502,8 +502,10 @@ class Metadata(Bcfg2.Server.Plugin.Metadata,
     """This class contains data for bcfg2 server metadata."""
     __author__ = 'bcfg-dev@mcs.anl.gov'
     sort_order = 500
-    __rmi__ = Bcfg2.Server.Plugin.DatabaseBacked.__rmi__ + ['list_clients',
-                                                            'remove_client']
+    __rmi__ = Bcfg2.Server.Plugin.DatabaseBacked.__rmi__ + \
+        ['list_clients', 'remove_client', 'get_all_group_names',
+         'get_all_groups_in_category', 'get_client_names_by_profiles',
+         'get_client_names_by_groups', 'get_client_names_by_bundles']
 
     options = Bcfg2.Server.Plugin.DatabaseBacked.options + [
         Bcfg2.Options.Common.password,
@@ -1315,6 +1317,7 @@ class Metadata(Bcfg2.Server.Plugin.Metadata,
         return set([g.name for g in self.groups.values()
                     if g.category == category])
 
+    @Bcfg2.Server.Plugin.rmi_list_argument
     def get_client_names_by_profiles(self, profiles):
         """ return a list of names of clients in the given profile groups """
         rv = []
@@ -1324,6 +1327,7 @@ class Metadata(Bcfg2.Server.Plugin.Metadata,
                 rv.append(client)
         return rv
 
+    @Bcfg2.Server.Plugin.rmi_list_argument
     def get_client_names_by_groups(self, groups):
         """ return a list of names of clients in the given groups """
         rv = []
@@ -1333,6 +1337,7 @@ class Metadata(Bcfg2.Server.Plugin.Metadata,
                 rv.append(client)
         return rv
 
+    @Bcfg2.Server.Plugin.rmi_list_argument
     def get_client_names_by_bundles(self, bundles):
         """ given a list of bundles, return a list of names of clients
         that use those bundles """


### PR DESCRIPTION
Our current implementation for "bcfg2-admin xcmd" does not support list
arguments for rmi calls. With the new decorater in Server.Plugin.helpers
all arguments are delivered as list to the rmi function.