### PR TITLE
Plugins/Packages: fix initialization of YumSource

### DIFF
--- a/src/lib/Bcfg2/Server/Plugins/Packages/Source.py
+++ b/src/lib/Bcfg2/Server/Plugins/Packages/Source.py
@@ -212,7 +212,7 @@ class Source(Bcfg2.Server.Plugin.Debuggable):  # pylint: disable=R0902
         #: compat with older code that relies on this.
         self.groups = []
 
-        self._init_attributes(basepath, xsource, setup)
+        self._init_attributes(xsource)
 
         #: A set of all package names in this source.  This will not
         #: necessarily be populated, particularly by backends that
@@ -271,7 +271,7 @@ class Source(Bcfg2.Server.Plugin.Debuggable):  # pylint: disable=R0902
                 setting['name'] = self.get_repo_name(setting)
             self.url_map.extend(usettings)
 
-    def _init_attributes(self, basepath, xsource, setup):
+    def _init_attributes(self, xsource):
         """
         This functions evaluates the Source tag and parses all
         attributes. Override this function in a sub class to
@@ -280,13 +280,8 @@ class Source(Bcfg2.Server.Plugin.Debuggable):  # pylint: disable=R0902
         need this specific fields. This functions is called before
         any other function.
 
-        :param basepath: The base filesystem path under which cache
-                         data for this source should be stored
-        :type basepath: string
         :param xsource: The XML tag that describes this source
         :type source: lxml.etree._Element
-        :param setup: A Bcfg2 options dict
-        :type setup: dict
         """
 
         self.components = [item.text for item in xsource.findall('Component')]

--- a/src/lib/Bcfg2/Server/Plugins/Packages/Yum.py
+++ b/src/lib/Bcfg2/Server/Plugins/Packages/Yum.py
@@ -1040,8 +1040,8 @@ class YumSource(Source):
         Source.__init__(self, basepath, xsource, setup)
     __init__.__doc__ = Source.__init__.__doc__
 
-    def _init_attributes(self, basepath, xsource, setup):
-        Source._init_attributes(self, basepath, xsource, setup)
+    def _init_attributes(self, xsource):
+        Source._init_attributes(self, xsource)
 
         if HAS_PULP and xsource.get("pulp_id"):
             self.pulp_id = xsource.get("pulp_id")

--- a/src/lib/Bcfg2/Server/Plugins/Packages/Yum.py
+++ b/src/lib/Bcfg2/Server/Plugins/Packages/Yum.py
@@ -1028,8 +1028,9 @@ class YumSource(Source):
     #: YumSource sets the ``type`` on Package entries to "yum"
     ptype = 'yum'
 
-    def __init__(self, basepath, xsource, setup):
-        Source.__init__(self, basepath, xsource, setup)
+    def _init_attributes(self, basepath, xsource, setup):
+        Source._init_attributes(self, basepath, xsource, setup)
+
         self.pulp_id = None
         if HAS_PULP and xsource.get("pulp_id"):
             self.pulp_id = xsource.get("pulp_id")
@@ -1071,7 +1072,7 @@ class YumSource(Source):
         self.needed_paths = set()
         self.file_to_arch = dict()
         self.yumgroups = dict()
-    __init__.__doc__ = Source.__init__.__doc__
+    _init_attributes.__doc__ = Source._init_attributes.__doc__
 
     @property
     def use_yum(self):

--- a/src/lib/Bcfg2/Server/Plugins/Packages/Yum.py
+++ b/src/lib/Bcfg2/Server/Plugins/Packages/Yum.py
@@ -1028,10 +1028,21 @@ class YumSource(Source):
     #: YumSource sets the ``type`` on Package entries to "yum"
     ptype = 'yum'
 
+    def __init__(self, basepath, xsource, setup):
+        self.filemap = dict()
+        self.file_to_arch = dict()
+        self.needed_paths = set()
+        self.packages = dict()
+        self.yumgroups = dict()
+        self.pulp_id = None
+        self.repo = None
+
+        Source.__init__(self, basepath, xsource, setup)
+    __init__.__doc__ = Source.__init__.__doc__
+
     def _init_attributes(self, basepath, xsource, setup):
         Source._init_attributes(self, basepath, xsource, setup)
 
-        self.pulp_id = None
         if HAS_PULP and xsource.get("pulp_id"):
             self.pulp_id = xsource.get("pulp_id")
 
@@ -1064,14 +1075,10 @@ class YumSource(Source):
                                      self.repo['relative_path'])
             self.arches = [self.repo['arch']]
 
-        self.packages = dict()
         self.deps = dict([('global', dict())])
         self.provides = dict([('global', dict())])
         self.filemap = dict([(x, dict())
                              for x in ['global'] + self.arches])
-        self.needed_paths = set()
-        self.file_to_arch = dict()
-        self.yumgroups = dict()
     _init_attributes.__doc__ = Source._init_attributes.__doc__
 
     @property


### PR DESCRIPTION
During ``__init__`` of the parent class ``get_repo_name`` is called. That needs
fields (``pump_id``) that are defined later in the ``__init__`` of YumSource.
We introduce the new function ``_init_attributes`` to parse all attributes
out of the ``<Source>`` tag before calling any other functions.