### PR TITLE
testsuite/requirements: python-daemon >= 2.0.0 is broken

### DIFF
--- a/testsuite/ext/ssl_protocols.py
+++ b/testsuite/ext/ssl_protocols.py
@@ -1,0 +1,17 @@
+try:
+    from logilab.astng import MANAGER, scoped_nodes, node_classes
+    PYLINT=0
+except ImportError:
+    from astroid import MANAGER, scoped_nodes, node_classes
+    PYLINT=1
+
+def ssl_transform(module):
+    if module.name == 'ssl':
+        for proto in ('SSLv23', 'TLSv1'):
+            module.locals['PROTOCOL_%s' % proto] = [node_classes.Const()]
+
+def register(linter):
+    if PYLINT == 0:
+        MANAGER.register_transformer(ssl_transform)
+    else:
+        MANAGER.register_transform(scoped_nodes.Module, ssl_transform)

--- a/testsuite/pylintrc.conf
+++ b/testsuite/pylintrc.conf
@@ -19,7 +19,7 @@ persistent=no
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
-load-plugins=ext.exception_messages
+load-plugins=ext.exception_messages,ext.ssl_protocols
 
 
 [MESSAGES CONTROL]

--- a/testsuite/requirements.txt
+++ b/testsuite/requirements.txt
@@ -4,4 +4,4 @@ mock
 sphinx
 pylint<1.0
 pep8
-python-daemon
+python-daemon<2.0.0


### PR DESCRIPTION
The new version of python-daemon is broken (at least pre-python2.7 support was dropped). This maybe fixes the recent travis error.