### PR TITLE
DBSettings: Fix time_zone option.

### DIFF
--- a/src/lib/Bcfg2/DBSettings.py
+++ b/src/lib/Bcfg2/DBSettings.py
@@ -109,7 +109,7 @@ def finalize_django_config(opts=None, silent=False):
             OPTIONS=opts.reporting_db_opts,
             SCHEMA=opts.reporting_db_schema)
 
-    settings['TIME_ZONE'] = opts.timezone
+    settings['TIME_ZONE'] = opts.time_zone
 
     settings['TEMPLATE_DEBUG'] = settings['DEBUG'] = \
         opts.web_debug
@@ -261,7 +261,7 @@ class _OptionContainer(object):
             type=Bcfg2.Options.Types.comma_dict, default=dict()),
         # Django options
         Bcfg2.Options.Option(
-            cf=('reporting', 'timezone'), help='Django timezone'),
+            cf=('reporting', 'time_zone'), help='Django timezone'),
         Bcfg2.Options.BooleanOption(
             cf=('reporting', 'web_debug'), help='Django debug'),
         Bcfg2.Options.Option(

--- a/testsuite/common.py
+++ b/testsuite/common.py
@@ -60,7 +60,7 @@ try:
     set_setup_default("db_port")
     set_setup_default("db_opts", dict())
     set_setup_default("db_schema")
-    set_setup_default("timezone")
+    set_setup_default("time_zone")
     set_setup_default("web_debug", False)
     set_setup_default("web_prefix")
 


### PR DESCRIPTION
In the documentation, in the 1.3.x version and in django this option
is called time_zone (and not timezone). There is no reason to change this.