### PR TITLE
Fix Decisions Plugin

### DIFF
--- a/src/lib/Bcfg2/Server/FileMonitor/Pseudo.py
+++ b/src/lib/Bcfg2/Server/FileMonitor/Pseudo.py
@@ -17,7 +17,8 @@ class Pseudo(FileMonitor):
     def AddMonitor(self, path, obj, handleID=None):
         if handleID is None:
             handleID = len(list(self.handles.keys()))
-        self.events.append(Event(handleID, path, 'exists'))
+        if os.path.exists(path):
+            self.events.append(Event(handleID, path, 'exists'))
         if os.path.isdir(path):
             dirlist = os.listdir(path)
             for fname in dirlist:

--- a/src/lib/Bcfg2/Server/Plugins/Decisions.py
+++ b/src/lib/Bcfg2/Server/Plugins/Decisions.py
@@ -27,8 +27,10 @@ class Decisions(Bcfg2.Server.Plugin.Plugin,
     def __init__(self, core):
         Bcfg2.Server.Plugin.Plugin.__init__(self, core)
         Bcfg2.Server.Plugin.Decision.__init__(self)
-        self.whitelist = DecisionFile(os.path.join(self.data, "whitelist.xml"))
-        self.blacklist = DecisionFile(os.path.join(self.data, "blacklist.xml"))
+        self.whitelist = DecisionFile(os.path.join(self.data, "whitelist.xml"),
+                                      should_monitor=True)
+        self.blacklist = DecisionFile(os.path.join(self.data, "blacklist.xml"),
+                                      should_monitor=True)
 
     def GetDecisions(self, metadata, mode):
         return getattr(self, mode).get_decisions(metadata)


### PR DESCRIPTION
Currently the Decisions plugin does not work because it does not monitors the files. The first patch add the monitoring and the second patch fixes the pseudo filemonitor for not generating the initial exists events, if the file does not exists.