### PR TITLE
Fix extra packages

### DIFF
--- a/src/lib/Bcfg2/Client/Tools/APT.py
+++ b/src/lib/Bcfg2/Client/Tools/APT.py
@@ -94,8 +94,8 @@ class APT(Bcfg2.Client.Tools.Tool):
         packages = [entry.get('name') for entry in self.getSupportedEntries()]
         extras = [(p.name, p.installed.version) for p in self.pkg_cache
                   if p.is_installed and p.name not in packages]
-        return [Bcfg2.Client.XML.Element('Package', name=name,
-                                         type='deb', version=version)
+        return [Bcfg2.Client.XML.Element('Package', name=name, type='deb',
+                                         current_version=version)
                 for (name, version) in extras]
 
     def VerifyDebsums(self, entry, modlist):

--- a/src/lib/Bcfg2/Client/Tools/Pkgng.py
+++ b/src/lib/Bcfg2/Client/Tools/Pkgng.py
@@ -66,8 +66,8 @@ class Pkgng(Bcfg2.Client.Tools.Tool):
         packages = [entry.get('name') for entry in self.getSupportedEntries()]
         extras = [(name, value) for (name, value) in self.pkg_cache.items()
                   if name not in packages]
-        return [Bcfg2.Client.XML.Element('Package', name=name,
-                                         type='pkgng', version=version)
+        return [Bcfg2.Client.XML.Element('Package', name=name, type='pkgng',
+                                         current_version=version)
                 for (name, version) in extras]
 
     def VerifyChecksums(self, entry, modlist):

--- a/src/lib/Bcfg2/Client/Tools/__init__.py
+++ b/src/lib/Bcfg2/Client/Tools/__init__.py
@@ -503,7 +503,8 @@ class PkgTool(Tool):
         extras = [data for data in list(self.installed.items())
                   if data[0] not in packages]
         return [Bcfg2.Client.XML.Element('Package', name=name,
-                                         type=self.pkgtype, version=version)
+                                         type=self.pkgtype,
+                                         current_version=version)
                 for (name, version) in extras]
     FindExtra.__doc__ = Tool.FindExtra.__doc__
 

--- a/src/lib/Bcfg2/Reporting/Storage/DjangoORM.py
+++ b/src/lib/Bcfg2/Reporting/Storage/DjangoORM.py
@@ -109,8 +109,8 @@ class DjangoORM(StorageBase):
         # extra entries are a bit different.  They can have Instance
         # objects
         if not act_dict['target_version']:
-            for instance in entry.findall("Instance"):
-                # FIXME - this probably only works for rpms
+            instance = entry.find("Instance")
+            if instance:
                 release = instance.get('release', '')
                 arch = instance.get('arch', '')
                 act_dict['current_version'] = instance.get('version')
@@ -118,9 +118,8 @@ class DjangoORM(StorageBase):
                     act_dict['current_version'] += "-" + release
                 if arch:
                     act_dict['current_version'] += "." + arch
-                self.logger.debug("Adding package %s %s" %
-                                  (name, act_dict['current_version']))
-                return PackageEntry.entry_get_or_create(act_dict)
+            self.logger.debug("Adding extra package %s %s" %
+                              (name, act_dict['current_version']))
         else:
             self.logger.debug("Adding package %s %s" %
                               (name, act_dict['target_version']))
@@ -128,7 +127,7 @@ class DjangoORM(StorageBase):
             # not implemented yet
             act_dict['verification_details'] = \
                 entry.get('verification_details', '')
-            return PackageEntry.entry_get_or_create(act_dict)
+        return PackageEntry.entry_get_or_create(act_dict)
 
     def _import_Path(self, entry, state):
         name = entry.get('name')


### PR DESCRIPTION
The handling of the reporting of extra packages was a bit strange. The version of the extra package was reported as `target_version` in the reporting. Only yum/rpm packages with a nested `<Instance>` tag parsed the version as current_version. 