### PR TITLE
Client/Tools/Pkgng: No auto-update on pkg-search.

### DIFF
--- a/src/lib/Bcfg2/Client/Tools/Pkgng.py
+++ b/src/lib/Bcfg2/Client/Tools/Pkgng.py
@@ -109,7 +109,7 @@ class Pkgng(Bcfg2.Client.Tools.Tool):
         Get versions of the specified package name available for
         installation from the configured remote repositories.
         """
-        output = self.cmd.run([self.pkg, 'search', '-Qversion', '-q',
+        output = self.cmd.run([self.pkg, 'search', '-U', '-Qversion', '-q',
                                '-Sname', '-e', name]).stdout.splitlines()
         versions = []
         for line in output:


### PR DESCRIPTION
By default pkg search will update the local copy of the repository
catalogue from remote. We are executing a lot of searches and do
not want to update the catalogue every time.