### PR TITLE
Client/Tools/APT: Fix regression of ee4111fc

### DIFF
--- a/src/lib/Bcfg2/Client/Tools/APT.py
+++ b/src/lib/Bcfg2/Client/Tools/APT.py
@@ -223,7 +223,7 @@ class APT(Bcfg2.Client.Tools.Tool):
                 except AttributeError:
                     self.logger.error("Failed to find %s in apt package "
                                       "cache" % pkgname)
-                    continue
+                continue
             avail_vers = self.pkg_cache[pkgname].versions.keys()
             if pkg.get('version') in avail_vers:
                 ipkgs.append("%s=%s" % (pkgname, pkg.get('version')))


### PR DESCRIPTION
In ee4111fc we removed the wrong continue (the one after the if/else block
for newapi) and now we get an error that 'auto' is not an available version.