### PR TITLE
Server/Plugins/Metadata: Reject passwd clients, if auth_type is cert

### DIFF
--- a/doc/releases/1.3.6.txt
+++ b/doc/releases/1.3.6.txt
@@ -30,5 +30,7 @@ This is primarily a bugfix release.
 
   https://docs.djangoproject.com/en/1.7/ref/settings/#std:setting-OPTIONS
 
+* Authentication: Reject passwd auth, if authentication is set to "cert"
+
 Special thanks to the following contributors for this release: Michael
 Fenn, Matt Kemp, Alexander Sulfrian, Jonathan Billings.

--- a/src/lib/Bcfg2/Server/Plugins/Metadata.py
+++ b/src/lib/Bcfg2/Server/Plugins/Metadata.py
@@ -1391,8 +1391,6 @@ class Metadata(Bcfg2.Server.Plugin.Metadata,
             # look at cert.cN
             client = certinfo['commonName']
             self.debug_log("Got cN %s; using as client name" % client)
-            auth_type = self.auth.get(client,
-                                      self.core.setup['authentication'])
         elif user == 'root':
             id_method = 'address'
             try:
@@ -1413,6 +1411,13 @@ class Metadata(Bcfg2.Server.Plugin.Metadata,
 
         # we have the client name
         self.debug_log("Authenticating client %s" % client)
+
+        # validate id_method
+        auth_type = self.auth.get(client, self.core.setup['authentication'])
+        if auth_type == 'cert' and id_method != 'cert':
+            self.logger.error("Client %s does not provide a cert, but only "
+                              "cert auth is allowed" % client)
+            return False
 
         # next we validate the address
         if (id_method != 'uuid' and


### PR DESCRIPTION
If the auth type (either globally or specific for the client) is set to cert auth,
we have to reject clients that does not provide a cert.