### PR TITLE
Fix pylint errors

### DIFF
--- a/src/lib/Bcfg2/Client/Tools/APT.py
+++ b/src/lib/Bcfg2/Client/Tools/APT.py
@@ -1,12 +1,10 @@
 """This is the Bcfg2 support for apt-get."""
 
-# suppress apt API warnings
-import warnings
-warnings.filterwarnings("ignore", "apt API not stable yet",
-                        FutureWarning)
-import apt.cache
 import os
 import sys
+
+import apt.cache
+
 import Bcfg2.Client.Tools
 
 
@@ -47,20 +45,20 @@ class APT(Bcfg2.Client.Tools.Tool):
                         for entry in struct
                         if entry.tag == 'Path' and
                         entry.get('type') == 'ignore']
-        self.__important__ = self.__important__ + \
-            ["%s/cache/debconf/config.dat" % self.var_path,
-             "%s/cache/debconf/templates.dat" % self.var_path,
-             '/etc/passwd', '/etc/group',
-             '%s/apt/apt.conf' % self.etc_path,
-             '%s/dpkg/dpkg.cfg' % self.etc_path] + \
+        self.__important__ = self.__important__ + [
+            "%s/cache/debconf/config.dat" % self.var_path,
+            "%s/cache/debconf/templates.dat" % self.var_path,
+            '/etc/passwd', '/etc/group',
+            '%s/apt/apt.conf' % self.etc_path,
+            '%s/dpkg/dpkg.cfg' % self.etc_path] + \
             [entry.get('name') for struct in config for entry in struct
-             if entry.tag == 'Path' and
-             entry.get('name').startswith(
-                 '%s/apt/sources.list' % self.etc_path)]
+             if (entry.tag == 'Path' and
+                 entry.get('name').startswith(
+                     '%s/apt/sources.list' % self.etc_path)]
         self.nonexistent = [entry.get('name') for struct in config
                             for entry in struct
-                            if entry.tag == 'Path' and
-                            entry.get('type') == 'nonexistent']
+                            if (entry.tag == 'Path' and
+                                entry.get('type') == 'nonexistent')]
         os.environ["DEBIAN_FRONTEND"] = 'noninteractive'
         self.actions = {}
         if self.setup['kevlar'] and not self.setup['dryrun']:

--- a/src/lib/Bcfg2/Client/Tools/MacPorts.py
+++ b/src/lib/Bcfg2/Client/Tools/MacPorts.py
@@ -42,10 +42,9 @@ class MacPorts(Bcfg2.Client.Tools.PkgTool):
             return False
 
         if entry.attrib['name'] in self.installed:
-            if (self.installed[entry.attrib['name']] == entry.attrib['version']
-                or entry.attrib['version'] == 'any'):
-                # if (not self.setup['quick'] and
-                #     entry.get('verify', 'true') == 'true'):
+            if (entry.attrib['version'] == 'any' or
+                    self.installed[entry.attrib['name']] ==
+                    entry.attrib['version']):
                 # FIXME: We should be able to check this once
                 #        http://trac.macports.org/ticket/15709 is implemented
                 return True

--- a/src/lib/Bcfg2/Client/Tools/POSIXUsers.py
+++ b/src/lib/Bcfg2/Client/Tools/POSIXUsers.py
@@ -146,8 +146,8 @@ class POSIXUsers(Bcfg2.Client.Tools.Tool):
         """ Get a list of supplmentary groups that the user in the
         given entry is a member of """
         return [g for g in self.existing['POSIXGroup'].values()
-                if entry.get("name") in g[3]
-                and self._in_managed_range('POSIXGroup', g[2])]
+                if entry.get("name") in g[3] and
+                self._in_managed_range('POSIXGroup', g[2])]
 
     def VerifyPOSIXUser(self, entry, _):
         """ Verify a POSIXUser entry """

--- a/src/lib/Bcfg2/Client/Tools/YUM.py
+++ b/src/lib/Bcfg2/Client/Tools/YUM.py
@@ -590,8 +590,8 @@ class YUM(Bcfg2.Client.Tools.PkgTool):
                                         "an RPM release")
                     continue
                 pkg_objs = [p for p in all_pkg_objs
-                            if (p.version == nevra['version']
-                                and p.release == nevra['release'])]
+                            if (p.version == nevra['version'] and
+                                p.release == nevra['release'])]
             else:
                 pkg_objs = self.yumbase.rpmdb.searchNevra(**short_yname(nevra))
             if len(pkg_objs) == 0:

--- a/src/lib/Bcfg2/Client/Tools/__init__.py
+++ b/src/lib/Bcfg2/Client/Tools/__init__.py
@@ -471,9 +471,9 @@ class PkgTool(Tool):
             # set all package states to true and flush workqueues
             pkgnames = [pkg.get('name') for pkg in packages]
             for entry in list(states.keys()):
-                if (entry.tag == 'Package'
-                    and entry.get('type') == self.pkgtype
-                    and entry.get('name') in pkgnames):
+                if (entry.tag == 'Package' and
+                        entry.get('type') == self.pkgtype and
+                        entry.get('name') in pkgnames):
                     self.logger.debug('Setting state to true for pkg %s' %
                                       entry.get('name'))
                     states[entry] = True
@@ -575,7 +575,7 @@ class SvcTool(Tool):
         return self.cmd.run(self.get_svc_command(service, 'stop'))
 
     def restart_service(self, service):
-        """ Restart a service.
+        """Restart a service.
 
         :param service: The service entry to modify
         :type service: lxml.etree._Element
@@ -608,8 +608,8 @@ class SvcTool(Tool):
             return
 
         for entry in bundle:
-            if (not self.handlesEntry(entry)
-                or not self._install_allowed(entry)):
+            if (not self.handlesEntry(entry) or
+                    not self._install_allowed(entry)):
                 continue
 
             estatus = entry.get('status')

--- a/src/lib/Bcfg2/Server/FileMonitor/__init__.py
+++ b/src/lib/Bcfg2/Server/FileMonitor/__init__.py
@@ -336,8 +336,11 @@ class FileMonitor(Debuggable):
 available = dict()  # pylint: disable=C0103
 
 # TODO: loading the monitor drivers should be automatic
-from Bcfg2.Server.FileMonitor.Pseudo import Pseudo
-available['pseudo'] = Pseudo
+try:
+    from Bcfg2.Server.FileMonitor.Pseudo import Pseudo
+    available['pseudo'] = Pseudo
+except ImportError:
+    pass
 
 try:
     from Bcfg2.Server.FileMonitor.Fam import Fam

--- a/src/lib/Bcfg2/Server/Lint/ValidateJSON.py
+++ b/src/lib/Bcfg2/Server/Lint/ValidateJSON.py
@@ -1,11 +1,13 @@
-"""Ensure that all JSON files in the Bcfg2 repository are
+"""Validate JSON files.
+
+Ensure that all JSON files in the Bcfg2 repository are
 valid. Currently, the only plugins that uses JSON are Ohai and
-Properties."""
+Properties.
+"""
 
 import os
 import sys
-import glob
-import fnmatch
+
 import Bcfg2.Server.Lint
 
 try:
@@ -48,18 +50,11 @@ class ValidateJSON(Bcfg2.Server.Lint.ServerlessPlugin):
     def get_files(self):
         """Return a list of all JSON files to validate, based on
         :attr:`Bcfg2.Server.Lint.ValidateJSON.ValidateJSON.globs`. """
-        if self.files is not None:
-            listfiles = lambda p: fnmatch.filter(self.files,
-                                                 os.path.join('*', p))
-        else:
-            listfiles = lambda p: glob.glob(os.path.join(self.config['repo'],
-                                                         p))
-
         rv = []
         for path in self.globs:
             if '/**/' in path:
                 if self.files is not None:
-                    rv.extend(listfiles(path))
+                    rv.extend(self.list_matching_files(path))
                 else:  # self.files is None
                     fpath, fname = path.split('/**/')
                     for root, _, files in \
@@ -68,5 +63,5 @@ class ValidateJSON(Bcfg2.Server.Lint.ServerlessPlugin):
                         rv.extend([os.path.join(root, f)
                                    for f in files if f == fname])
             else:
-                rv.extend(listfiles(path))
+                rv.extend(self.list_matching_files(path))
         return rv

--- a/src/lib/Bcfg2/Server/Lint/__init__.py
+++ b/src/lib/Bcfg2/Server/Lint/__init__.py
@@ -1,14 +1,19 @@
 """ Base classes for Lint plugins and error handling """
 
 import os
+import fnmatch
+import glob
 import sys
 import logging
 from copy import copy
 import textwrap
+import time
+
 import lxml.etree
 import fcntl
 import termios
 import struct
+
 from Bcfg2.Compat import walk_packages
 
 plugins = [m[1] for m in walk_packages(path=__path__)]  # pylint: disable=C0103
@@ -138,6 +143,13 @@ class Plugin(object):
                 element,
                 xml_declaration=False).decode("UTF-8").strip()
         return "   line %s: %s" % (element.sourceline, xml)
+
+    def list_matching_files(self, path):
+        """list all files matching the path in self.files or the bcfg2 repo."""
+        if self.files is not None:
+            return fnmatch.filter(self.files, os.path.join('*', path))
+        else:
+            return glob.glob(os.path.join(self.config['repo'], path))
 
 
 class ErrorHandler(object):

--- a/src/lib/Bcfg2/Server/Plugin/__init__.py
+++ b/src/lib/Bcfg2/Server/Plugin/__init__.py
@@ -11,11 +11,6 @@ documentation it's not necessary to use the submodules.  E.g., you can
 
     from Bcfg2.Server.Plugin.base import Plugin
 """
-
-import os
-import sys
-sys.path.append(os.path.dirname(__file__))
-
 # pylint: disable=W0401
 from Bcfg2.Server.Plugin.base import *
 from Bcfg2.Server.Plugin.interfaces import *

--- a/src/lib/Bcfg2/Server/Plugins/GroupPatterns.py
+++ b/src/lib/Bcfg2/Server/Plugins/GroupPatterns.py
@@ -149,15 +149,13 @@ class GroupPatternsLint(Bcfg2.Server.Lint.ServerPlugin):
 
     def check(self, entry, groups, ptype="NamePattern"):
         """ Check a single pattern for validity """
-        if ptype == "NamePattern":
-            pmap = lambda p: PatternMap(p, None, groups)
-        else:
-            pmap = lambda p: PatternMap(None, p, groups)
-
         for el in entry.findall(ptype):
             pat = el.text
             try:
-                pmap(pat)
+                if ptype == "NamePattern":
+                    PatternMap(pat, None, groups)
+                else:
+                    PatternMap(None, pat, groups)
             except:  # pylint: disable=W0702
                 err = sys.exc_info()[1]
                 self.LintError("pattern-fails-to-initialize",

--- a/src/lib/Bcfg2/Server/Plugins/SSLCA.py
+++ b/src/lib/Bcfg2/Server/Plugins/SSLCA.py
@@ -150,15 +150,13 @@ class SSLCAEntrySet(Bcfg2.Server.Plugin.EntrySet):
             if passphrase:
                 cmd.extend(["-passin", "pass:%s" % passphrase])
 
-                def _scrub_pass(arg):
-                    """ helper to scrub the passphrase from the
-                    argument list """
-                    if arg.startswith("pass:"):
-                        return "pass:******"
-                    else:
-                        return arg
-            else:
-                _scrub_pass = lambda a: a
+            def _scrub_pass(arg):
+                """ helper to scrub the passphrase from the
+                argument list for debugging. """
+                if arg.startswith("pass:"):
+                    return "pass:******"
+                else:
+                    return arg
 
             self.debug_log("SSLCA: Generating new certificate: %s" %
                            " ".join(_scrub_pass(a) for a in cmd))
@@ -362,9 +360,12 @@ class SSLCA(Bcfg2.Server.Plugin.GroupSpool):
     """ The SSLCA generator handles the creation and management of ssl
     certificates and their keys. """
     __author__ = 'g.hagger@gmail.com'
-    # python 2.5 doesn't support mixing *magic and keyword arguments
-    es_cls = lambda self, *args: SSLCAEntrySet(*args, **dict(parent=self))
     es_child_cls = SSLCADataFile
+
+    def es_cls(self, *args):
+        """Fake entry set 'class' that sets this as the parent."""
+        # python 2.5 doesn't support mixing *magic and keyword arguments
+        return SSLCAEntrySet(*args, **dict(parent=self))
 
     def get_ca(self, name):
         """ get a dict describing a CA from the config file """

--- a/src/sbin/bcfg2-test
+++ b/src/sbin/bcfg2-test
@@ -20,7 +20,10 @@ try:
     HAS_MULTIPROC = True
 except ImportError:
     HAS_MULTIPROC = False
-    active_children = lambda: []  # pylint: disable=C0103
+
+    def active_children():
+        """active_children() when multiprocessing lib is missing."""
+        return []
 
 
 class CapturingLogger(object):

--- a/testsuite/requirements.txt
+++ b/testsuite/requirements.txt
@@ -2,6 +2,6 @@ lxml
 nose
 mock
 sphinx
-pylint<1.0
+pylint<0.29
 pep8
 python-daemon<2.0.0


### PR DESCRIPTION
This also pins pylint to <= 0.28 so we don't have to keep playing
whack-a-mole with it.

Also removes unnecessary suppression of apt warnings. This is no
longer necessary in 12.04, so should be safe to remove. If you're on
Ubuntu < 12.04, upgrade for heaven's sake.