### PR TITLE
SSLCA.py: Use utf8 for consistency

### DIFF
--- a/src/lib/Bcfg2/Server/Plugins/SSLCA.py
+++ b/src/lib/Bcfg2/Server/Plugins/SSLCA.py
@@ -197,7 +197,8 @@ class SSLCAEntrySet(Bcfg2.Server.Plugin.EntrySet):
                 'distinguished_name': 'req_distinguished_name',
                 'req_extensions': 'v3_req',
                 'x509_extensions': 'v3_req',
-                'prompt': 'no'
+                'prompt': 'no',
+                'string_mask': 'utf8only'
             },
             'req_distinguished_name': {},
             'v3_req': {


### PR DESCRIPTION
We may want to enforce utf-8 for consistency. The downside to doing so is that it limits the CA configuration to utf-8. However, given that some distros (CentOS6) set the string_mask to this by default, the plugin will work more seamlessly by default in those situations.