### PR TITLE
Server/Plugins/Packages: Fix _init_attributes position.

### DIFF
--- a/src/lib/Bcfg2/Server/Plugins/Packages/Source.py
+++ b/src/lib/Bcfg2/Server/Plugins/Packages/Source.py
@@ -212,8 +212,6 @@ class Source(Bcfg2.Server.Plugin.Debuggable):  # pylint: disable=R0902
         #: compat with older code that relies on this.
         self.groups = []
 
-        self._init_attributes(xsource)
-
         #: A set of all package names in this source.  This will not
         #: necessarily be populated, particularly by backends that
         #: reimplement large portions of
@@ -231,6 +229,8 @@ class Source(Bcfg2.Server.Plugin.Debuggable):  # pylint: disable=R0902
         #: particularly by backends that reimplement large portions of
         #: :class:`Bcfg2.Server.Plugins.Packages.Collection.Collection`
         self.provides = dict()
+
+        self._init_attributes(xsource)
 
         #: The file (or directory) used for this source's cache data
         self.cachefile = os.path.join(self.basepath,


### PR DESCRIPTION
``_init_attributes`` should be called after all properties of the ``Source`` class
are initialized (so that ``_init_attributes`` could overwrite some of it).
The ``Yum`` class initializes ``self.deps`` with a different default entry, that
should not be reset by ``__init__`` of ``Source`` afterwards.