### PR TITLE
Server: Ignore directories containing a .bcfg2-ignore file

### DIFF
--- a/doc/releases/1.4.0pre2.txt
+++ b/doc/releases/1.4.0pre2.txt
@@ -31,6 +31,9 @@ backwards-incompatible user-facing changes
   This fixes potentially long client runs when comparing files that have
   diverged significantly.
 
+* Ignore directories containing a .bcfg2-ignore file in various plugins
+  (Bundler, Defaults, Pkgmgr, Properties, PuppetENC, TemplateHelper, Trigger).
+
 Thanks
 ------
 

--- a/src/lib/Bcfg2/Server/Plugin/helpers.py
+++ b/src/lib/Bcfg2/Server/Plugin/helpers.py
@@ -456,7 +456,9 @@ class DirectoryBacked(Debuggable):
             # again without having to add a new monitor.
         elif os.path.isdir(abspath):
             # Deal with events for directories
-            if action in ['exists', 'created']:
+            if os.path.exists(os.path.join(abspath, '.bcfg2-ignore')):
+                self.logger.debug("Ignoring directory %s" % abspath)
+            elif action in ['exists', 'created']:
                 self.add_directory_monitor(relpath)
             elif action == 'changed':
                 if relpath in self.entries:


### PR DESCRIPTION
The DirectoryBacked helper now does not recurse into directories that
contains a .bcfg2-ignore file. This makes it possible to ignore some
directories for most plugins (Bundler, Defaults, Pkgmgr, Properties,
PuppetENC, TemplateHelper, Trigger). You can store for example a python
module used by a TemplateHelper in the same directory, without getting
strange error messages while TemplateHelper is trying to import each
single file of this module.