### PR TITLE
Fix some issues with new Options parser in tools/

### DIFF
--- a/tools/upgrade/1.3/migrate_info.py
+++ b/tools/upgrade/1.3/migrate_info.py
@@ -48,9 +48,11 @@ def main():
     parser.parse()
 
     for plugin in Bcfg2.Options.setup.plugins:
-        if plugin not in ['SSLCA', 'Cfg', 'TGenshi', 'TCheetah', 'SSHbase']:
+        plugin_name = plugin.__name__
+        if plugin_name not in ['SSLCA', 'Cfg', 'TGenshi', 'TCheetah',
+                               'SSHbase']:
             continue
-        datastore = os.path.join(Bcfg2.Options.setup.repository, plugin)
+        datastore = os.path.join(Bcfg2.Options.setup.repository, plugin_name)
         for root, dirs, files in os.walk(datastore):
             for fname in files:
                 if fname in [":info", "info"]:

--- a/tools/upgrade/1.3/migrate_perms_to_mode.py
+++ b/tools/upgrade/1.3/migrate_perms_to_mode.py
@@ -64,7 +64,7 @@ def main():
     parser = Bcfg2.Options.get_parser(
         description="Migrate from Bcfg2 1.2 'perms' attribute to 1.3 'mode' "
         "attribute",
-        components=FileMonitor)
+        components=[FileMonitor])
     parser.add_options([Bcfg2.Options.Common.repository,
                         Bcfg2.Options.Common.plugins])
     parser.parse()

--- a/tools/upgrade/1.3/migrate_perms_to_mode.py
+++ b/tools/upgrade/1.3/migrate_perms_to_mode.py
@@ -71,17 +71,19 @@ def main():
     repo = Bcfg2.Options.setup.repository
 
     for plugin in Bcfg2.Options.setup.plugins:
-        if plugin in ['Base', 'Bundler', 'Rules']:
-            for root, _, files in os.walk(os.path.join(repo, plugin)):
+        plugin_name = plugin.__name__
+        if plugin_name in ['Base', 'Bundler', 'Rules']:
+            for root, _, files in os.walk(os.path.join(repo, plugin_name)):
                 if skip_path(root):
                     continue
                 for fname in files:
                     if skip_path(fname):
                         continue
                     convertstructure(os.path.join(root, fname))
-        if plugin not in ['Cfg', 'TGenshi', 'TCheetah', 'SSHbase', 'SSLCA']:
+        if plugin_name not in ['Cfg', 'TGenshi', 'TCheetah', 'SSHbase',
+                               'SSLCA']:
             continue
-        for root, dirs, files in os.walk(os.path.join(repo, plugin)):
+        for root, dirs, files in os.walk(os.path.join(repo, plugin_name)):
             if skip_path(root):
                 continue
             for fname in files:


### PR DESCRIPTION
Hi,

the migration to the new parser for Options has introduced some small issues in tools/. The new parser does not read the Plugin names from the config but instantiates the full Plugin classes. So we need `__name__` to access the raw name.

Another issue is, that the components should be specified as list, even if it is only one.


Alex