### PR TITLE
PrioDir: Only set text content, if something is available

### DIFF
--- a/src/lib/Bcfg2/Server/Plugin/helpers.py
+++ b/src/lib/Bcfg2/Server/Plugin/helpers.py
@@ -1064,7 +1064,8 @@ class PrioDir(Plugin, Generator, XMLDirectoryBacked):
                     data = candidate
                     break
 
-        entry.text = data.text
+        if data.text is not None and data.text.strip() != '':
+            entry.text = data.text
         for item in data.getchildren():
             entry.append(copy.copy(item))
 


### PR DESCRIPTION
This is used for the Rules and Defaults plugins. Without this patch all text
content that was there before (for example file content bound by Cfg) is lost,
for all entries specified in Defaults.