### PR TITLE
Lint/MergeFiles: Ignore binary files

### DIFF
--- a/src/lib/Bcfg2/Client/Tools/POSIX/File.py
+++ b/src/lib/Bcfg2/Client/Tools/POSIX/File.py
@@ -8,6 +8,7 @@ import tempfile
 import Bcfg2.Options
 from Bcfg2.Client.Tools.POSIX.base import POSIXTool
 from Bcfg2.Compat import unicode, b64encode, b64decode  # pylint: disable=W0622
+import Bcfg2.Utils
 
 
 class POSIXFile(POSIXTool):
@@ -16,21 +17,6 @@ class POSIXFile(POSIXTool):
 
     def fully_specified(self, entry):
         return entry.text is not None or entry.get('empty', 'false') == 'true'
-
-    def _is_string(self, strng, encoding):
-        """ Returns true if the string contains no ASCII control
-        characters and can be decoded from the specified encoding. """
-        for char in strng:
-            if ord(char) < 9 or ord(char) > 13 and ord(char) < 32:
-                return False
-        if not hasattr(strng, "decode"):
-            # py3k
-            return True
-        try:
-            strng.decode(encoding)
-            return True
-        except:  # pylint: disable=W0702
-            return False
 
     def _get_data(self, entry):
         """ Get a tuple of (<file data>, <is binary>) for the given entry """
@@ -181,8 +167,8 @@ class POSIXFile(POSIXTool):
                                   (entry.get("name"), sys.exc_info()[1]))
                 return False
         if not is_binary:
-            is_binary |= not self._is_string(content,
-                                             Bcfg2.Options.setup.encoding)
+            is_binary |= not Bcfg2.Utils.is_string(
+                content, Bcfg2.Options.setup.encoding)
         if is_binary:
             # don't compute diffs if the file is binary
             prompt.append('Binary file, no printable diff')

--- a/src/lib/Bcfg2/Server/Lint/MergeFiles.py
+++ b/src/lib/Bcfg2/Server/Lint/MergeFiles.py
@@ -6,6 +6,7 @@ import copy
 from difflib import SequenceMatcher
 import Bcfg2.Server.Lint
 from Bcfg2.Server.Plugins.Cfg import CfgGenerator
+from Bcfg2.Utils import is_string
 
 
 def threshold(val):
@@ -15,12 +16,6 @@ def threshold(val):
     if rv > 1:
         rv /= 100
     return rv
-
-
-def is_binary(data):
-    """ Check if a given string contains only text or binary data. """
-    text_chars = bytearray([7, 8, 9, 10, 12, 13, 27] + range(0x20, 0x100))
-    return bool(data.translate(None, text_chars))
 
 
 class MergeFiles(Bcfg2.Server.Lint.ServerPlugin):
@@ -56,7 +51,8 @@ class MergeFiles(Bcfg2.Server.Lint.ServerPlugin):
         for filename, entryset in self.core.plugins['Cfg'].entries.items():
             candidates = dict([(f, e) for f, e in entryset.entries.items()
                                if (isinstance(e, CfgGenerator) and
-                                   not is_binary(e.data) and
+                                   is_string(e.data,
+                                             Bcfg2.Options.setup.encoding) and
                                    f not in ignore and
                                    not f.endswith(".crypt"))])
             similar, identical = self.get_similar(candidates)

--- a/src/lib/Bcfg2/Server/Lint/MergeFiles.py
+++ b/src/lib/Bcfg2/Server/Lint/MergeFiles.py
@@ -17,6 +17,12 @@ def threshold(val):
     return rv
 
 
+def is_binary(data):
+    """ Check if a given string contains only text or binary data. """
+    text_chars = bytearray([7, 8, 9, 10, 12, 13, 27] + range(0x20, 0x100))
+    return bool(data.translate(None, text_chars))
+
+
 class MergeFiles(Bcfg2.Server.Lint.ServerPlugin):
     """ find Probes or Cfg files with multiple similar files that
     might be merged into one """
@@ -50,6 +56,7 @@ class MergeFiles(Bcfg2.Server.Lint.ServerPlugin):
         for filename, entryset in self.core.plugins['Cfg'].entries.items():
             candidates = dict([(f, e) for f, e in entryset.entries.items()
                                if (isinstance(e, CfgGenerator) and
+                                   not is_binary(e.data) and
                                    f not in ignore and
                                    not f.endswith(".crypt"))])
             similar, identical = self.get_similar(candidates)

--- a/src/lib/Bcfg2/Utils.py
+++ b/src/lib/Bcfg2/Utils.py
@@ -330,3 +330,19 @@ class classproperty(object):  # pylint: disable=C0103
 
     def __get__(self, instance, owner):
         return self.getter(owner)
+
+
+def is_string(strng, encoding):
+    """ Returns true if the string contains no ASCII control
+    characters and can be decoded from the specified encoding. """
+    for char in strng:
+        if ord(char) < 9 or ord(char) > 13 and ord(char) < 32:
+            return False
+    if not hasattr(strng, "decode"):
+        # py3k
+        return True
+    try:
+        strng.decode(encoding)
+        return True
+    except:  # pylint: disable=W0702
+        return False

--- a/testsuite/Testsrc/Testlib/TestUtils.py
+++ b/testsuite/Testsrc/Testlib/TestUtils.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import os
 import sys
 from Bcfg2.Utils import *
@@ -42,3 +43,17 @@ class TestPackedDigitRange(Bcfg2TestCase):
             for test in exc:
                 self.assertNotIn(test, rng)
                 self.assertFalse(rng.includes(test))
+
+
+class TestIsString(Bcfg2TestCase):
+    def test_is_string(self):
+        for char in list(range(8)) + list(range(14, 32)):
+            self.assertFalse(is_string("foo" + chr(char) + "bar", 'UTF-8'))
+        for char in list(range(9, 14)) + list(range(33, 128)):
+            self.assertTrue(is_string("foo" + chr(char) + "bar", 'UTF-8'))
+
+        ustr = 'é'
+        self.assertTrue(is_string(ustr, 'UTF-8'))
+        if not inPy3k:
+            self.assertFalse(is_string("foo" + chr(128) + "bar", 'ascii'))
+            self.assertFalse(is_string(ustr, 'ascii'))


### PR DESCRIPTION
Ignore files with binary content, because SequenceMatcher seems to have problems
and sometimes detect files with different content as identically.