### PR TITLE
Options: Set default values from config, right after adding a new option

### DIFF
--- a/src/lib/Bcfg2/Options/Parser.py
+++ b/src/lib/Bcfg2/Options/Parser.py
@@ -141,6 +141,9 @@ class Parser(argparse.ArgumentParser):
 
                 self.option_list.extend(option.list_options())
                 option.add_to_parser(self)
+                for opt in option.list_options():
+                    opt.default_from_config(self._cfp)
+                    self._defaults_set.append(opt)
 
     def add_component(self, component):
         """ Add a component (and all of its options) to the

--- a/testsuite/Testsrc/Testlib/TestOptions/TestComponents.py
+++ b/testsuite/Testsrc/Testlib/TestOptions/TestComponents.py
@@ -182,7 +182,8 @@ class TestImportComponentOptions(OptionTestCase):
     """test cases for component loading."""
 
     def setUp(self):
-        self.options = [Option("--cls", action=ImportComponentAction),
+        self.options = [Option("--cls", cf=("config", "cls"),
+                               action=ImportComponentAction),
                         Option("--module", action=ImportModuleAction)]
 
         self.result = argparse.Namespace()
@@ -227,3 +228,10 @@ class TestImportComponentOptions(OptionTestCase):
         self.assertRaises(SystemExit,
                           self.parser.parse,
                           ["-C", config_file, "--cls", "Bcfg2.No.Such.Thing"])
+
+    @make_config({"config": {"test": "foo", "cls": "Two"}})
+    def test_default_from_config_for_component_options(self, config_file):
+        """use default value from config file for options added by dynamic loaded component."""
+        self.parser.parse(["-C", config_file])
+        self.assertEqual(self.result.cls, Two.Two)
+        self.assertEqual(self.result.test, "foo")

--- a/testsuite/Testsrc/Testlib/TestOptions/Two.py
+++ b/testsuite/Testsrc/Testlib/TestOptions/Two.py
@@ -1,6 +1,7 @@
 """Test module for component loading."""
+from Bcfg2.Options import Option
 
 
 class Two(object):
     """Test class for component loading."""
-    pass
+    options = [Option('--test', cf=("config", "test"), dest="test", default="bar")]


### PR DESCRIPTION
If adding an option during the "Main Parser Loop" (for example because of loading
a component for bcfg-lint) a value for the option from the config file is simply
ignored.

After adding the option the parser first tries to find the value in the command line,
but cannot find it and set the default value from the source code as option value.
After that the value from the config file is set as new default. But because the
option already is in the Namespace, it does not use the new "default" value from the
config file.

This patch simply sets the default value from the config file, right after the new option
is added to the parser and so the correct value is used afterwards, if the parsed cannot
find the flag on the command line.