### PR TITLE
Rules: New options replace_name to replace ${name} in attributes

### DIFF
--- a/doc/releases/1.4.0pre2.txt
+++ b/doc/releases/1.4.0pre2.txt
@@ -19,6 +19,7 @@ environments.
 
 * NagiosGen: Add bundles to configuration
 * HomeBrew: Initial add of plugin
+* Rules/Defaults: Add possibility to use name of entry in attributes
 
 backwards-incompatible user-facing changes
 ------------------------------------------

--- a/doc/server/plugins/generators/rules.txt
+++ b/doc/server/plugins/generators/rules.txt
@@ -512,3 +512,23 @@ you'd have to explicitly specify ``<Service name="bcfg2.*".../>``.
 
 Note that only one Rule can apply to any abstract entry, so you cannot
 specify multiple regexes to match the same rule.
+
+Replacing the name of the Entry in Attributes
+=============================================
+
+If you are using regular expressions to match the abstract configuration
+entries, you may need the concrete name of the entry in some attributes.
+To use this feature, you have to enable it. It is only useful, if used
+together with regex matching. ::
+
+    [rules]
+    regex = yes
+    replace_name = yes
+
+You now can write something like that in your xml file:
+
+.. code-block:: xml
+
+    <POSIXUser name='.*' home='/somewhere/%{name}'/>
+
+``%{name}`` will be correctly replaced with the username for each POSIXUser.

--- a/doc/server/plugins/structures/defaults.txt
+++ b/doc/server/plugins/structures/defaults.txt
@@ -29,3 +29,10 @@ on Fedora 15 and the ``chkconfig`` tool on Fedora 14, you could do::
 If you were to specify a ``type`` attribute for a Service entry in
 Rules (or a ``type`` attribute for a BoundService entry in Bundler),
 that would take precendence over the default.
+
+Like :ref:`server-plugins-generators-rules`, Defaults can also replace
+``%{name}`` in attributes with the real name of the entry. To enable this,
+add the following setting to ``bcfg2.conf``::
+
+    [defaults]
+    replace_name = yes

--- a/src/lib/Bcfg2/Server/Plugin/helpers.py
+++ b/src/lib/Bcfg2/Server/Plugin/helpers.py
@@ -1064,6 +1064,20 @@ class PrioDir(Plugin, Generator, XMLDirectoryBacked):
                     data = candidate
                     break
 
+        self._apply(entry, data)
+
+    def _apply(self, entry, data):
+        """ Apply all available values from data onto entry. This
+        sets the available attributes (for all attribues unset in
+        the entry), adds all children and copies the text from data
+        to entry.
+
+        :param entry: The entry to apply the changes
+        :type entry: lxml.etree._Element
+        :param data: The entry to get the data from
+        :type data: lxml.etree._Element
+        """
+
         if data.text is not None and data.text.strip() != '':
             entry.text = data.text
         for item in data.getchildren():

--- a/src/lib/Bcfg2/Server/Plugins/Defaults.py
+++ b/src/lib/Bcfg2/Server/Plugins/Defaults.py
@@ -1,5 +1,6 @@
 """This generator provides rule-based entry mappings."""
 
+import Bcfg2.Options
 import Bcfg2.Server.Plugin
 import Bcfg2.Server.Plugins.Rules
 
@@ -9,7 +10,10 @@ class Defaults(Bcfg2.Server.Plugins.Rules.Rules,
     """Set default attributes on bound entries"""
     __author__ = 'bcfg-dev@mcs.anl.gov'
 
-    options = Bcfg2.Server.Plugin.PrioDir.options
+    options = Bcfg2.Server.Plugin.PrioDir.options + [
+        Bcfg2.Options.BooleanOption(
+            cf=("defaults", "replace_name"), dest="defaults_replace_name",
+            help="Replace %{name} in attributes with name of target entry")]
 
     # Rules is a Generator that happens to implement all of the
     # functionality we want, so we overload it, but Defaults should
@@ -41,3 +45,9 @@ class Defaults(Bcfg2.Server.Plugins.Rules.Rules,
     def _regex_enabled(self):
         """ Defaults depends on regex matching, so force it enabled """
         return True
+
+    @property
+    def _replace_name_enabled(self):
+        """ Return True if the replace_name feature is enabled,
+        False otherwise """
+        return Bcfg2.Options.setup.defaults_replace_name

--- a/src/lib/Bcfg2/Server/Plugins/Rules.py
+++ b/src/lib/Bcfg2/Server/Plugins/Rules.py
@@ -1,8 +1,15 @@
 """This generator provides rule-based entry mappings."""
 
+import copy
 import re
+import string
 import Bcfg2.Options
 import Bcfg2.Server.Plugin
+
+
+class NameTemplate(string.Template):
+    """Simple subclass of string.Template with a custom delimiter."""
+    delimiter = '%'
 
 
 class Rules(Bcfg2.Server.Plugin.PrioDir):
@@ -12,7 +19,10 @@ class Rules(Bcfg2.Server.Plugin.PrioDir):
     options = Bcfg2.Server.Plugin.PrioDir.options + [
         Bcfg2.Options.BooleanOption(
             cf=("rules", "regex"), dest="rules_regex",
-            help="Allow regular expressions in Rules")]
+            help="Allow regular expressions in Rules"),
+        Bcfg2.Options.BooleanOption(
+            cf=("rules", "replace_name"), dest="rules_replace_name",
+            help="Replace %{name} in attributes with name of target entry")]
 
     def __init__(self, core):
         Bcfg2.Server.Plugin.PrioDir.__init__(self, core)
@@ -46,7 +56,22 @@ class Rules(Bcfg2.Server.Plugin.PrioDir):
                 return True
         return False
 
+    def _apply(self, entry, data):
+        if self._replace_name_enabled:
+            data = copy.deepcopy(data)
+            for key, val in list(data.attrib.items()):
+                data.attrib[key] = NameTemplate(val).safe_substitute(
+                    name=entry.get('name'))
+
+        Bcfg2.Server.Plugin.PrioDir._apply(self, entry, data)
+
     @property
     def _regex_enabled(self):
         """ Return True if rules regexes are enabled, False otherwise """
         return Bcfg2.Options.setup.rules_regex
+
+    @property
+    def _replace_name_enabled(self):
+        """ Return True if the replace_name feature is enabled,
+        False otherwise """
+        return Bcfg2.Options.setup.rules_replace_name

--- a/testsuite/Testsrc/Testlib/TestServer/TestPlugins/TestDefaults.py
+++ b/testsuite/Testsrc/Testlib/TestServer/TestPlugins/TestDefaults.py
@@ -22,6 +22,10 @@ from Testinterfaces import TestGoalValidator
 class TestDefaults(TestRules, TestGoalValidator):
     test_obj = Defaults
 
+    def setUp(self):
+        TestRules.setUp(self)
+        set_setup_default("defaults_replace_name", True)
+
     def get_obj(self, *args, **kwargs):
         return TestRules.get_obj(self, *args, **kwargs)
 
@@ -91,3 +95,8 @@ class TestDefaults(TestRules, TestGoalValidator):
 
     def test_regex(self):
         self._do_test('regex')
+
+    def test_replace_name(self):
+        Bcfg2.Options.setup.defaults_replace_name = True
+        self._do_test('replace_name')
+        Bcfg2.Options.setup.defaults_replace_name = False

--- a/testsuite/common.py
+++ b/testsuite/common.py
@@ -171,21 +171,22 @@ class Bcfg2TestCase(TestCase):
             msg = "XML trees are not equal: %s"
         else:
             msg += ": %s"
-        fullmsg = msg + "\nFirst:  %s" % lxml.etree.tostring(el1) + \
+        msg += "\n%s"
+        fullmsg = "First:  %s" % lxml.etree.tostring(el1) + \
             "\nSecond: %s" % lxml.etree.tostring(el2)
 
-        self.assertEqual(el1.tag, el2.tag, msg=fullmsg % "Tags differ")
+        self.assertEqual(el1.tag, el2.tag, msg=msg % ("Tags differ", fullmsg))
         if el1.text is not None and el2.text is not None:
             self.assertEqual(el1.text.strip(), el2.text.strip(),
-                             msg=fullmsg % "Text content differs")
+                             msg=msg % ("Text content differs", fullmsg))
         else:
             self.assertEqual(el1.text, el2.text,
-                             msg=fullmsg % "Text content differs")
+                             msg=msg % ("Text content differs", fullmsg))
         self.assertItemsEqual(el1.attrib.items(), el2.attrib.items(),
-                              msg=fullmsg % "Attributes differ")
+                              msg=msg % ("Attributes differ", fullmsg))
         self.assertEqual(len(el1.getchildren()),
                          len(el2.getchildren()),
-                         msg=fullmsg % "Different numbers of children")
+                         msg=msg % ("Different numbers of children", fullmsg))
         matched = []
         for child1 in el1.getchildren():
             for child2 in el2.xpath(child1.tag):
@@ -199,10 +200,10 @@ class Bcfg2TestCase(TestCase):
                     continue
             else:
                 assert False, \
-                    fullmsg % ("Element %s is missing from second" %
-                               lxml.etree.tostring(child1))
+                    msg % ("Element %s is missing from second" %
+                               lxml.etree.tostring(child1), fullmsg)
         self.assertItemsEqual(el2.getchildren(), matched,
-                              msg=fullmsg % "Second has extra element(s)")
+                              msg=msg % ("Second has extra element(s)", fullmsg))
 
 
 class DBModelTestCase(Bcfg2TestCase):


### PR DESCRIPTION
If you use the regex feature of Rules/Defaults you may need the real name
of the matched entry in an attribute (for example home of POSIXUser).
You can now enable replace_name for rules or defaults and ${name} will be
replaces in the attribues of the Element before adding them to the target
entry.

This allows you to write something like that in Defaults to assing a default
home directory somewhere else to all users with unset home:

    <POSIXUser name='.*' home='/somewhere/${name}'/>