### PR TITLE
Admin: Add expirecache command, remove it from Info

### DIFF
--- a/src/lib/Bcfg2/Options/Subcommands.py
+++ b/src/lib/Bcfg2/Options/Subcommands.py
@@ -82,6 +82,7 @@ class Subcommand(object):
         """
         if args is not None:
             self.parser.namespace = copy.copy(master_setup)
+            self.parser.parsed = False
             alist = shlex.split(args)
             try:
                 setup = self.parser.parse(alist)

--- a/src/lib/Bcfg2/Server/Admin.py
+++ b/src/lib/Bcfg2/Server/Admin.py
@@ -439,6 +439,25 @@ class Compare(AdminCmd):
                 print("")
 
 
+class ExpireCache(_ProxyAdminCmd):
+    """ Expire the metadata cache """
+
+    options = _ProxyAdminCmd.options + [
+        Bcfg2.Options.PositionalArgument(
+            "hostname", nargs="*", default=[],
+            help="Expire cache for the given host(s)")]
+
+    def run(self, setup):
+        clients = None
+        if setup.hostname is not None and len(setup.hostname) > 0:
+            clients = setup.hostname
+
+        try:
+            self.proxy.expire_metadata_cache(clients)
+        except Bcfg2.Client.Proxy.ProxyError:
+            self.errExit("Proxy Error: %s" % sys.exc_info()[1])
+
+
 class Init(AdminCmd):
     """Interactively initialize a new repository."""
 

--- a/src/lib/Bcfg2/Server/Core.py
+++ b/src/lib/Bcfg2/Server/Core.py
@@ -114,7 +114,8 @@ class DefaultACL(Plugin, ClientACLs):
     def check_acl_ip(self, address, rmi):
         return (("." not in rmi and
                  not rmi.endswith("_debug") and
-                 rmi != 'get_statistics') or
+                 rmi != 'get_statistics' and
+                 rmi != 'expire_metadata_cache') or
                 address[0] == "127.0.0.1")
 
 # in core we frequently want to catch all exceptions, regardless of

--- a/src/lib/Bcfg2/Server/Core.py
+++ b/src/lib/Bcfg2/Server/Core.py
@@ -1366,6 +1366,21 @@ class Core(object):
         return "This method is deprecated and will be removed in a future " + \
             "release\n%s" % self.fam.set_debug(debug)
 
+    @exposed
+    def expire_metadata_cache(self, _, hostnames=None):
+        """ Expire the metadata cache for one or all clients
+
+        :param hostnames: A list of hostnames to expire the metadata
+                          cache for or None. If None the cache of
+                          all clients will be expired.
+        :type hostnames: None or list of strings
+        """
+        if hostnames is not None:
+            for hostname in hostnames:
+                self.metadata_cache.expire(hostname)
+        else:
+            self.metadata_cache.expire()
+
 
 class NetworkCore(Core):
     """ A server core that actually listens on the network, can be

--- a/src/lib/Bcfg2/Server/Info.py
+++ b/src/lib/Bcfg2/Server/Info.py
@@ -385,6 +385,15 @@ class ExpireCache(InfoCmd):
             self.core.metadata_cache.expire()
 
 
+class EventDebug(InfoCmd):
+    """ Enable debugging output for FAM events """
+    only_interactive = True
+    aliases = ['event_debug']
+
+    def run(self, _):
+        self.core.fam.set_debug(True)
+
+
 class Bundles(InfoCmd):
     """ Print out group/bundle info """
 
@@ -673,6 +682,15 @@ class Query(InfoCmd):
         print("\n".join(res))
 
 
+class Quit(InfoCmd):
+    """ Exit program """
+    only_interactive = True
+    aliases = ['exit', 'EOF']
+
+    def run(self, _):
+        raise SystemExit(0)
+
+
 class Shell(InfoCmd):
     """ Open an interactive shell to run multiple bcfg2-info commands """
     interactive = False
@@ -683,6 +701,14 @@ class Shell(InfoCmd):
                                   'Type "help" for more information')
         except KeyboardInterrupt:
             print("\nCtrl-C pressed, exiting...")
+
+
+class Update(InfoCmd):
+    """ Process pending filesystem events """
+    only_interactive = True
+
+    def run(self, _):
+        self.core.fam.handle_events_in_interval(0.1)
 
 
 class ProfileTemplates(InfoCmd):
@@ -869,23 +895,6 @@ class CLI(cmd.Cmd, Bcfg2.Options.CommandRegistry):
         methods and not the class, because the CommandRegistry
         dynamically adds methods for the registed subcommands. """
         return dir(self)
-
-    def do_quit(self, _):
-        """ quit|exit - Exit program """
-        raise SystemExit(0)
-
-    do_EOF = do_quit
-    do_exit = do_quit
-
-    def do_eventdebug(self, _):
-        """ eventdebug - Enable debugging output for FAM events """
-        self.core.fam.set_debug(True)
-
-    do_event_debug = do_eventdebug
-
-    def do_update(self, _):
-        """ update - Process pending filesystem events """
-        self.core.fam.handle_events_in_interval(0.1)
 
     def onecmd(self, line):
         """ Overwrite cmd.Cmd.onecmd to catch all exceptions (except

--- a/src/lib/Bcfg2/Server/Info.py
+++ b/src/lib/Bcfg2/Server/Info.py
@@ -370,6 +370,7 @@ class Automatch(InfoCmd):
 
 class ExpireCache(InfoCmd):
     """ Expire the metadata cache """
+    only_interactive = True
 
     options = [
         Bcfg2.Options.PositionalArgument(

--- a/src/lib/Bcfg2/Server/Info.py
+++ b/src/lib/Bcfg2/Server/Info.py
@@ -377,12 +377,11 @@ class ExpireCache(InfoCmd):
             help="Expire cache for the given host(s)")]
 
     def run(self, setup):
-        if setup.clients:
-            for client in self.get_client_list(setup.clients):
-                self.core.expire_caches_by_type(Bcfg2.Server.Plugin.Metadata,
-                                                key=client)
+        if setup.hostname:
+            for client in self.get_client_list(setup.hostname):
+                self.core.metadata_cache.expire(client)
         else:
-            self.core.expire_caches_by_type(Bcfg2.Server.Plugin.Metadata)
+            self.core.metadata_cache.expire()
 
 
 class Bundles(InfoCmd):


### PR DESCRIPTION
The expirecache command of bcfg2-info was pretty useless, because bcfg2-info
will start a new server process and expire cache cleared the cache in that
process but does not communicate with a running server.

Now expirecache is part of bcfg2-admin and will call expire_metadata_cache
from Core via XML-RPC. This will expire the metadata cache of the supplied
clients, or the complete cache if no arguments are supplied.