### PR TITLE
Expire metadata cache in all Connector plugins.

### DIFF
--- a/doc/development/plugins.txt
+++ b/doc/development/plugins.txt
@@ -118,7 +118,9 @@ Invalidating Caches
 In Bcfg2 1.3.0, some limited :ref:`server-caching` was introduced.  If
 you are writing a :class:`Bcfg2.Server.Plugin.interfaces.Connector`
 plugin that implements
-:func:`Bcfg2.Server.Plugin.interfaces.Connector.get_additional_groups`,
+:func:`Bcfg2.Server.Plugin.interfaces.Connector.get_additional_groups`
+or
+:func:`Bcfg2.Server.Plugin.interfaces.Connector.get_additional_data`,
 then you need to be able to invalidate the server metadata cache in
 order to be compatible with the ``cautious`` or ``aggressive`` caching
 modes.
@@ -140,9 +142,9 @@ called with one string argument, it expires cached data for the named
 client.
 
 It's important, therefore, that your Connector plugin can either track
-when changes are made to the group membership it reports, and expire
-cached data appropriately when in ``cautious`` or ``aggressive`` mode;
-or prudently flag an incompatibility with those two modes.
+when changes are made to the data or group membership it reports, and
+expire cached data appropriately when in ``cautious`` or ``aggressive``
+mode; or prudently flag an incompatibility with those two modes.
 
 For examples, see:
 

--- a/src/lib/Bcfg2/Server/Plugins/AWSTags.py
+++ b/src/lib/Bcfg2/Server/Plugins/AWSTags.py
@@ -172,6 +172,11 @@ class AWSTags(Bcfg2.Server.Plugin.Plugin,
 
     def start_client_run(self, metadata):
         self.expire_cache(key=metadata.hostname)
+        if self.core.metadata_cache_mode == 'aggressive':
+            self.logger.warning("AWSTags is incompatible with aggressive "
+                                "client metadata caching, try 'cautious' "
+                                "or 'initial'")
+            self.core.metadata_cache.expire(metadata.hostname)
 
     def get_additional_data(self, metadata):
         return self.get_tags(metadata)

--- a/src/lib/Bcfg2/Server/Plugins/GroupLogic.py
+++ b/src/lib/Bcfg2/Server/Plugins/GroupLogic.py
@@ -13,6 +13,17 @@ class GroupLogicConfig(Bcfg2.Server.Plugin.StructFile):
     create = lxml.etree.Element("GroupLogic",
                                 nsmap=dict(py="http://genshi.edgewall.org/"))
 
+    def __init__(self, filename, core):
+        Bcfg2.Server.Plugin.StructFile.__init__(self, filename,
+                                                should_monitor=True)
+        self.core = core
+
+    def Index(self):
+        Bcfg2.Server.Plugin.StructFile.Index(self)
+
+        if self.core.metadata_cache_mode in ['cautious', 'aggressive']:
+            self.core.metadata_cache.expire()
+
     def _match(self, item, metadata, *args):
         if item.tag == 'Group' and not len(item.getchildren()):
             return [item]
@@ -39,7 +50,7 @@ class GroupLogic(Bcfg2.Server.Plugin.Plugin,
         Bcfg2.Server.Plugin.Plugin.__init__(self, core)
         Bcfg2.Server.Plugin.Connector.__init__(self)
         self.config = GroupLogicConfig(os.path.join(self.data, "groups.xml"),
-                                       should_monitor=True)
+                                       core=core)
         self._local = local()
 
     def get_additional_groups(self, metadata):

--- a/src/lib/Bcfg2/Server/Plugins/Ohai.py
+++ b/src/lib/Bcfg2/Server/Plugins/Ohai.py
@@ -94,7 +94,12 @@ class Ohai(Bcfg2.Server.Plugin.Plugin,
         return [self.probe]
 
     def ReceiveData(self, meta, datalist):
-        self.cache[meta.hostname] = datalist[0].text
+        if meta.hostname not in self.cache or \
+           self.cache[meta.hostname] != datalist[0].text:
+            self.cache[meta.hostname] = datalist[0].text
+
+            if self.core.metadata_cache_mode in ['cautious', 'aggressive']:
+                self.core.metadata_cache.expire(meta.hostname)
 
     def get_additional_data(self, meta):
         if meta.hostname in self.cache:

--- a/src/lib/Bcfg2/Server/Plugins/PuppetENC.py
+++ b/src/lib/Bcfg2/Server/Plugins/PuppetENC.py
@@ -117,7 +117,7 @@ class PuppetENC(Bcfg2.Server.Plugin.Plugin,
             self.logger.warning("PuppetENC is incompatible with aggressive "
                                 "client metadata caching, try 'cautious' or "
                                 "'initial' instead")
-            self.core.expire_caches_by_type(Bcfg2.Server.Plugin.Metadata)
+            self.core.metadata_cache.expire()
 
     def end_statistics(self, metadata):
         self.end_client_run(self, metadata)

--- a/src/lib/Bcfg2/Server/Plugins/SSHbase.py
+++ b/src/lib/Bcfg2/Server/Plugins/SSHbase.py
@@ -286,6 +286,10 @@ class SSHbase(Bcfg2.Server.Plugin.Plugin,
                     self.debug_log("New public key %s; invalidating "
                                    "ssh_known_hosts cache" % event.filename)
                     self.skn = False
+
+                    if self.core.metadata_cache_mode in ['cautious',
+                                                         'aggressive']:
+                        self.core.metadata_cache.expire()
                 return
 
         if event.filename == 'info.xml':

--- a/testsuite/Testsrc/Testlib/TestServer/TestPlugins/TestProperties.py
+++ b/testsuite/Testsrc/Testlib/TestServer/TestPlugins/TestProperties.py
@@ -29,11 +29,14 @@ class TestPropertyFile(Bcfg2TestCase):
     test_obj = PropertyFile
     path = os.path.join(datastore, "test")
 
-    def get_obj(self, path=None):
+    def get_obj(self, path=None, core=None, *args, **kwargs):
         set_setup_default("writes_enabled", False)
         if path is None:
             path = self.path
-        return self.test_obj(path)
+        if core is None:
+            core = Mock()
+            core.metadata_cache_mode = 'none'
+        return self.test_obj(path, core, *args, **kwargs)
 
     def test_write(self):
         pf = self.get_obj()
@@ -97,6 +100,9 @@ class TestJSONPropertyFile(TestFileBacked, TestPropertyFile):
         TestFileBacked.setUp(self)
         TestPropertyFile.setUp(self)
 
+    def get_obj(self, *args, **kwargs):
+        return TestPropertyFile.get_obj(self, *args, **kwargs)
+
     @patch("%s.loads" % JSON)
     def test_Index(self, mock_loads):
         pf = self.get_obj()
@@ -136,6 +142,9 @@ class TestYAMLPropertyFile(TestFileBacked, TestPropertyFile):
     def setUp(self):
         TestFileBacked.setUp(self)
         TestPropertyFile.setUp(self)
+
+    def get_obj(self, *args, **kwargs):
+        return TestPropertyFile.get_obj(self, *args, **kwargs)
 
     @patch("yaml.load")
     def test_Index(self, mock_load):
@@ -179,7 +188,7 @@ class TestXMLPropertyFile(TestPropertyFile, TestStructFile):
         set_setup_default("automatch", False)
 
     def get_obj(self, *args, **kwargs):
-        return TestStructFile.get_obj(self, *args, **kwargs)
+        return TestPropertyFile.get_obj(self, *args, **kwargs)
 
     @patch("%s.open" % builtins)
     def test__write(self, mock_open):

--- a/testsuite/Testsrc/Testlib/TestServer/TestPlugins/TestTemplateHelper.py
+++ b/testsuite/Testsrc/Testlib/TestServer/TestPlugins/TestTemplateHelper.py
@@ -22,10 +22,13 @@ class TestHelperModule(Bcfg2TestCase):
     test_obj = HelperModule
     path = os.path.join(datastore, "test.py")
 
-    def get_obj(self, path=None):
+    def get_obj(self, path=None, core=None):
         if path is None:
             path = self.path
-        return self.test_obj(path)
+        if core is None:
+            core = Mock()
+            core.metadata_cache_mode = 'none'
+        return self.test_obj(path, core)
 
     def test__init(self):
         hm = self.get_obj()


### PR DESCRIPTION
The plugins need to expire the metadata_cache, even if they only implement `Bcfg2.Server.Plugin.interfaces.Connector.get_additional_data`. This expires the
metadata_cache in all plugins and updates to docs.

The AWSTags plugin is incompatible with aggressive caching mode (like PuppetEnc).
Maybe we should do something like with Packages. The plugins cache the results
indefinitely and it can be refreshed with an xcmd command, but that would be another
pull request.