### PR TITLE
Client/Tools/Systemd: Do not stop services if status is set to ignore

### DIFF
--- a/src/lib/Bcfg2/Client/Tools/Systemd.py
+++ b/src/lib/Bcfg2/Client/Tools/Systemd.py
@@ -84,7 +84,7 @@ class Systemd(Bcfg2.Client.Tools.SvcTool):
         else:
             if entry.get('status') == 'on':
                 cmd = self.get_svc_command(entry, 'start')
-            else:
+            elif entry.get('status') == 'off':
                 cmd = self.get_svc_command(entry, 'stop')
 
         if cmd:


### PR DESCRIPTION
If bootstatus is set to something and status is set to ignore for a systemd service,
we do not want to stop this service.