### PR TITLE
doc: update Genshi 'name' attribute description

### DIFF
--- a/doc/server/plugins/generators/cfg.txt
+++ b/doc/server/plugins/generators/cfg.txt
@@ -275,9 +275,7 @@ Several variables are pre-defined inside templates:
 |             | <server-plugins-grouping-metadata-clientmetadata>`     |
 +-------------+--------------------------------------------------------+
 | name        | The value of the ``name`` attribute as specified in    |
-|             | the Path entry in Bcfg2.  If an :ref:`altsrc           |
-|             | <server-plugins-structures-altsrc>` attribute is used, |
-|             | then ``name`` will be the value of that attribute.     |
+|             | the Path entry in Bcfg2.                               |
 +-------------+--------------------------------------------------------+
 | source_path | The path to the template file on the filesystem        |
 +-------------+--------------------------------------------------------+


### PR DESCRIPTION
Seems current description was added in https://github.com/Bcfg2/bcfg2/commit/255046b3f3484219bbfa6646c88bbc4bbc1b5256 , but is not valid anymore.
Corresponding code:
https://github.com/Bcfg2/bcfg2/blob/master/src/lib/Bcfg2/Server/Core.py#L633
`name` corresponds to `altsrc` only when `realname` attribute is also present; and in https://github.com/Bcfg2/bcfg2/blob/master/src/lib/Bcfg2/Server/Plugin/helpers.py#L107 `realname` has the precedence over `name`.