### PR TITLE
Logging: Fix message building

### DIFF
--- a/src/lib/Bcfg2/Logger.py
+++ b/src/lib/Bcfg2/Logger.py
@@ -41,6 +41,8 @@ class TermiosFormatter(logging.Formatter):
         returns = []
         line_len = self.width
         if isinstance(record.msg, str):
+            if len(record.args) != 0:
+                record.msg = record.msg % record.args
             for line in record.msg.split('\n'):
                 if len(line) <= line_len:
                     returns.append(line)


### PR DESCRIPTION
The `logging.LogRecord` instance could contain `args` to replace some
placeholders in the format string in `msg`.