### PR TITLE
Run the superclass shutdown() to correctly set self.started

### DIFF
--- a/src/lib/Bcfg2/Server/FileMonitor/Inotify.py
+++ b/src/lib/Bcfg2/Server/FileMonitor/Inotify.py
@@ -214,6 +214,7 @@ class Inotify(Pseudo, pyinotify.ProcessEvent):
     def shutdown(self):
         if self.started and self.notifier:
             self.notifier.stop()
+        Pseudo.shutdown(self)
     shutdown.__doc__ = Pseudo.shutdown.__doc__
 
     def list_watches(self):


### PR DESCRIPTION
The superclass sets self.started to False which makes sure the logic works correctly and notifier.stop() does not get run more than once.