### PR TITLE
Some more django fixes

### DIFF
--- a/src/lib/Bcfg2/Reporting/templates/clients/detailed-list.html
+++ b/src/lib/Bcfg2/Reporting/templates/clients/detailed-list.html
@@ -25,7 +25,7 @@ This is needed for Django versions less than 1.5
   </tr>
   {% for entry in entry_list %}
   <tr class='{% cycle listview,listview_alt %}'>
-    <td class='left_column'><a href='{% url "Bcfg2.Reporting.views.client_detail" hostname=entry.client.name pk=entry.id %}'>{{ entry.client.name }}</a></td>
+    <td class='left_column'><a href='{% url "reports_client_detail_pk" hostname=entry.client.name pk=entry.id %}'>{{ entry.client.name }}</a></td>
     <td class='right_column' style='width:75px'><a href='{% add_url_filter state=entry.state %}'
       class='{{entry|determine_client_state}}'>{{ entry.state }}</a></td>
     <td class='right_column_narrow'>{{ entry.good_count }}</td>

--- a/src/lib/Bcfg2/Reporting/templates/widgets/interaction_list.inc
+++ b/src/lib/Bcfg2/Reporting/templates/widgets/interaction_list.inc
@@ -15,7 +15,7 @@
   </tr>
   {% for entry in entry_list %}
   <tr class='{% cycle listview,listview_alt %}'>
-    <td class='left_column'><a href='{% url reports_client_detail_pk hostname=entry.client.name, pk=entry.id %}' class="white-space: nowrap;">
+    <td class='left_column'><a href='{% url "reports_client_detail_pk" hostname=entry.client.name pk=entry.id %}' class="white-space: nowrap;">
       {{ entry.timestamp|date:"SHORT_DATETIME_FORMAT"|safe }}
     </a></td>
     {% if not client %}

--- a/src/lib/Bcfg2/Server/Plugins/Metadata.py
+++ b/src/lib/Bcfg2/Server/Plugins/Metadata.py
@@ -35,6 +35,7 @@ def load_django_models():
     # pylint: enable=W0602
 
     try:
+        import django
         from django.db import models
         HAS_DJANGO = True
     except ImportError:
@@ -98,6 +99,9 @@ def load_django_models():
                 return True
             except MetadataClientModel.DoesNotExist:
                 return False
+
+    if django.VERSION[0] == 1 and django.VERSION[1] >= 7:
+        django.setup()  # pylint: disable=E1101
 
 
 class XMLMetadataConfig(Bcfg2.Server.Plugin.XMLFileBacked):


### PR DESCRIPTION
Here are some more django fixes:

* Fix the database backend for the Metadata plugin (requires the same handling for django1.7 like the reporting database backend with `django.setup()`)
* Add a remaining fix for django1.5, that was missing in 84a83ca. (The first parameter of the `url` template tag has to be quoted.)
* Use consistent syntax for the `url` template tag and remove deprecated (in django1.8) syntax. The `url` template tag should be called with an identifier and not with the python dotted path of a view function.

Hopefully the last django1.7 fixes ;) 