### PR TITLE
Client/Tools: Fix error if no pkg handled

### DIFF
--- a/src/lib/Bcfg2/Client/Tools/APT.py
+++ b/src/lib/Bcfg2/Client/Tools/APT.py
@@ -236,7 +236,7 @@ class APT(Bcfg2.Client.Tools.Tool):
             self.logger.error("Cannot find correct versions of packages:")
             self.logger.error(bad_pkgs)
         if not ipkgs:
-            return
+            return dict()
         if not self.cmd.run(self.pkgcmd % (" ".join(ipkgs))):
             self.logger.error("APT command failed")
         self.pkg_cache = apt.cache.Cache()

--- a/src/lib/Bcfg2/Client/Tools/Pkgng.py
+++ b/src/lib/Bcfg2/Client/Tools/Pkgng.py
@@ -205,7 +205,7 @@ class Pkgng(Bcfg2.Client.Tools.Tool):
             self.logger.error("Cannot find correct versions of packages:")
             self.logger.error(bad_pkgs)
         if not ipkgs:
-            return
+            return dict()
         if not self.cmd.run(self.pkgcmd % (" ".join(ipkgs))):
             self.logger.error("pkg command failed")
         self._load_pkg_cache()


### PR DESCRIPTION
`Install()` of a client tool returns the changed states as dict, that will update
the global state. If nothing is handled withing a tool, it have to return an empty
dict and not None because the return value is directly used as argument for update:

> APT.Install() call failed:
> Traceback (most recent call last):
>   File "/usr/lib/python2.7/dist-packages/Bcfg2/Client/__init__.py", line 739, in DispatchInstallCalls
>    self.states.update(tool.Install(handled))
> TypeError: 'NoneType' object is not iterable