### PR TITLE
Lint/TemplateHelper: Fix parameters

### DIFF
--- a/src/lib/Bcfg2/Server/Lint/TemplateHelper.py
+++ b/src/lib/Bcfg2/Server/Lint/TemplateHelper.py
@@ -26,7 +26,7 @@ class TemplateHelper(ServerPlugin):
         ServerPlugin.__init__(self, *args, **kwargs)
         # we instantiate a dummy helper to discover which keywords and
         # defaults are reserved
-        dummy = HelperModule("foo.py")
+        dummy = HelperModule("foo.py", None)
         self.reserved_keywords = dir(dummy)
         self.reserved_defaults = dummy.reserved_defaults
 


### PR DESCRIPTION
The HelperModules of the TemplateHelper now expects a second argument with
the core, to be able to expire the metadata cache.

This is a fix-up for 36b2aa66627a4cc147f982d03688ae9df14bbe08.