### PR TITLE
bcfg2 server sends a complete SELinux context, but we only need the t…

### DIFF
--- a/src/lib/Bcfg2/Client/Tools/POSIX/base.py
+++ b/src/lib/Bcfg2/Client/Tools/POSIX/base.py
@@ -562,7 +562,7 @@ class POSIXTool(Bcfg2.Client.Tools.Tool):
                 except OSError:
                     errors.append("%s has no default SELinux context" %
                                   entry.get("name"))
-            else:
+            elif entry.get("secontext"):
                 wanted_secontext = entry.get("secontext").split(":")[2]
             if (wanted_secontext and
                     attrib['current_secontext'] != wanted_secontext):

--- a/src/lib/Bcfg2/Client/Tools/POSIX/base.py
+++ b/src/lib/Bcfg2/Client/Tools/POSIX/base.py
@@ -563,7 +563,7 @@ class POSIXTool(Bcfg2.Client.Tools.Tool):
                     errors.append("%s has no default SELinux context" %
                                   entry.get("name"))
             else:
-                wanted_secontext = entry.get("secontext")
+                wanted_secontext = entry.get("secontext").split(":")[2]
             if (wanted_secontext and
                     attrib['current_secontext'] != wanted_secontext):
                 errors.append("SELinux context for path %s is incorrect. "


### PR DESCRIPTION
bcfg2 server sends a complete SELinux context, but we only need the type.  Treat this the same as selinux.matchpathcon.