### PR TITLE
Allow multiline scripts with indentation in bcfg2-info debug mode

### DIFF
--- a/src/sbin/bcfg2-info
+++ b/src/sbin/bcfg2-info
@@ -185,9 +185,8 @@ class InfoCore(cmd.Cmd, Bcfg2.Server.Core.BaseCore):
                 interactive = False
         if scriptmode:
             console = InteractiveConsole(locals())
-            for command in [c.strip() for c in open(spath).readlines()]:
-                if command:
-                    console.push(command)
+            for command in open(spath).readlines():
+                console.push(command.rstrip())
         if interactive:
             interpreters = load_interpreters()
             if self.setup['interpreter'] in interpreters:


### PR DESCRIPTION
This should allow to execute python scripts with indentation through bcfg2-info debug command.
