### PR TITLE
testsuite: Change imports for newer mock versions (maint)

### DIFF
--- a/testsuite/Testsrc/Testlib/TestClient/TestTools/TestPOSIXUsers.py
+++ b/testsuite/Testsrc/Testlib/TestClient/TestTools/TestPOSIXUsers.py
@@ -105,26 +105,26 @@ class TestPOSIXUsers(TestTool):
         # test failure of inherited method
         entry = lxml.etree.Element("POSIXUser", name="test")
         self.assertFalse(users.canInstall(entry))
-        mock_canInstall.assertCalledWith(users, entry)
+        mock_canInstall.assert_called_with(users, entry)
 
         # test with no uid specified
         reset()
         mock_canInstall.return_value = True
         self.assertTrue(users.canInstall(entry))
-        mock_canInstall.assertCalledWith(users, entry)
+        mock_canInstall.assert_called_with(users, entry)
 
         # test with uid specified, not in managed range
         reset()
         entry.set("uid", "1000")
         self.assertFalse(users.canInstall(entry))
-        mock_canInstall.assertCalledWith(users, entry)
+        mock_canInstall.assert_called_with(users, entry)
         users._in_managed_range.assert_called_with(entry.tag, "1000")
 
         # test with uid specified, in managed range
         reset()
         users._in_managed_range.return_value = True
         self.assertTrue(users.canInstall(entry))
-        mock_canInstall.assertCalledWith(users, entry)
+        mock_canInstall.assert_called_with(users, entry)
         users._in_managed_range.assert_called_with(entry.tag, "1000")
 
     @patch("Bcfg2.Client.Tools.Tool.Inventory")

--- a/testsuite/Testsrc/Testlib/TestServer/TestPlugins/TestProbes.py
+++ b/testsuite/Testsrc/Testlib/TestServer/TestPlugins/TestProbes.py
@@ -46,7 +46,7 @@ class FakeElement(lxml.etree._Element):
 
 
 class StoringElement(object):
-    OriginalElement = copy.copy(lxml.etree.Element)
+    OriginalElement = staticmethod(copy.copy(lxml.etree.Element))
 
     def __init__(self):
         self.element = None
@@ -59,7 +59,7 @@ class StoringElement(object):
 
 
 class StoringSubElement(object):
-    OriginalSubElement = copy.copy(lxml.etree.SubElement)
+    OriginalSubElement = staticmethod(copy.copy(lxml.etree.SubElement))
 
     def __call__(self, parent, tag, **kwargs):
         try:

--- a/testsuite/common.py
+++ b/testsuite/common.py
@@ -14,7 +14,10 @@ import sys
 import codecs
 import unittest
 import lxml.etree
-from mock import patch, MagicMock, _patch, DEFAULT
+try:
+    from mock.mock import patch, MagicMock, _patch, DEFAULT
+except ImportError:
+    from mock import patch, MagicMock, _patch, DEFAULT
 from Bcfg2.Compat import wraps
 
 #: The path to the Bcfg2 specification root for the tests.  Using the


### PR DESCRIPTION
This is a backport of #326 for maint. So that we can fix the test cases for other fixes like #329.