### PR TITLE
Fix a variety of problems with YumHelper

### DIFF
--- a/src/lib/Bcfg2/Server/Plugins/Packages/Yum.py
+++ b/src/lib/Bcfg2/Server/Plugins/Packages/Yum.py
@@ -456,16 +456,13 @@ class YumCollection(Collection):
                 reponame = basereponame
 
                 added = False
+                rid = 1
                 while not added:
                     try:
                         config.add_section(reponame)
                         added = True
                     except ConfigParser.DuplicateSectionError:
-                        match = re.search(r'-(\d+)', reponame)
-                        if match:
-                            rid = int(match.group(1)) + 1
-                        else:
-                            rid = 1
+                        rid += 1
                         reponame = "%s-%d" % (basereponame, rid)
 
                 config.set(reponame, "name", reponame)

--- a/src/lib/Bcfg2/Server/Plugins/Packages/YumHelper.py
+++ b/src/lib/Bcfg2/Server/Plugins/Packages/YumHelper.py
@@ -377,7 +377,7 @@ class CLI(Bcfg2.Options.CommandRegistry):
             "-c", "--yum-config", help="Yum config file"),
         Bcfg2.Options.PositionalArgument(
             "command", help="Yum helper command",
-            choices=['clean', 'complete', 'get_groups'])]
+            choices=['clean', 'makecache', 'complete', 'get_groups'])]
 
     def __init__(self):
         Bcfg2.Options.CommandRegistry.__init__(self)

--- a/src/lib/Bcfg2/Server/Plugins/Packages/YumHelper.py
+++ b/src/lib/Bcfg2/Server/Plugins/Packages/YumHelper.py
@@ -274,15 +274,13 @@ class HelperSubcommand(Bcfg2.Options.Subcommand):
     # whether or not this command accepts input on stdin
     accept_input = True
 
-    def __init__(self):
-        Bcfg2.Options.Subcommand.__init__(self)
+    def run(self, setup):
         self.verbosity = 0
         if Bcfg2.Options.setup.debug:
             self.verbosity = 5
         elif Bcfg2.Options.setup.verbose:
             self.verbosity = 1
 
-    def run(self, setup):
         try:
             data = json.loads(sys.stdin.read())
         except ValueError:
@@ -310,8 +308,8 @@ class DepSolverSubcommand(HelperSubcommand):  # pylint: disable=W0223
     """ Base class for helper commands that use the depsolver (i.e.,
     only resolve dependencies, don't modify the cache) """
 
-    def __init__(self):
-        HelperSubcommand.__init__(self)
+    def run(self):
+        HelperSubcommand.run(self)
         self.depsolver = DepSolver(Bcfg2.Options.setup.yum_config,
                                    self.verbosity)
 
@@ -322,8 +320,8 @@ class CacheManagerSubcommand(HelperSubcommand):  # pylint: disable=W0223
     fallback = False
     accept_input = False
 
-    def __init__(self):
-        HelperSubcommand.__init__(self)
+    def run(self):
+        HelperSubcommand.run(self)
         self.cachemgr = CacheManager(Bcfg2.Options.setup.yum_config,
                                      self.verbosity)
 

--- a/src/lib/Bcfg2/Server/Plugins/Packages/YumHelper.py
+++ b/src/lib/Bcfg2/Server/Plugins/Packages/YumHelper.py
@@ -281,6 +281,20 @@ class HelperSubcommand(Bcfg2.Options.Subcommand):
         elif Bcfg2.Options.setup.verbose:
             self.verbosity = 1
 
+    def _run(self, setup, data):
+        """ Actually run the command """
+        raise NotImplementedError
+
+
+class DepSolverSubcommand(HelperSubcommand):  # pylint: disable=W0223
+    """ Base class for helper commands that use the depsolver (i.e.,
+    only resolve dependencies, don't modify the cache) """
+
+    def run(self, setup):
+        HelperSubcommand.run(self, setup)
+        self.depsolver = DepSolver(Bcfg2.Options.setup.yum_config,
+                                   self.verbosity)
+
         try:
             data = json.loads(sys.stdin.read())
         except ValueError:
@@ -293,25 +307,11 @@ class HelperSubcommand(Bcfg2.Options.Subcommand):
             print(json.dumps(self._run(setup, data)))
         except:  # pylint: disable=W0702
             self.logger.error("Unexpected error running %s: %s" %
-                              self.__class__.__name__.lower(),
-                              sys.exc_info()[1], exc_info=1)
+                              (self.__class__.__name__.lower(),
+                               sys.exc_info()[1]), exc_info=1)
             print(json.dumps(self.fallback))
             return 2
         return 0
-
-    def _run(self, setup, data):
-        """ Actually run the command """
-        raise NotImplementedError
-
-
-class DepSolverSubcommand(HelperSubcommand):  # pylint: disable=W0223
-    """ Base class for helper commands that use the depsolver (i.e.,
-    only resolve dependencies, don't modify the cache) """
-
-    def run(self):
-        HelperSubcommand.run(self)
-        self.depsolver = DepSolver(Bcfg2.Options.setup.yum_config,
-                                   self.verbosity)
 
 
 class CacheManagerSubcommand(HelperSubcommand):  # pylint: disable=W0223
@@ -320,10 +320,20 @@ class CacheManagerSubcommand(HelperSubcommand):  # pylint: disable=W0223
     fallback = False
     accept_input = False
 
-    def run(self):
-        HelperSubcommand.run(self)
+    def run(self, setup):
+        HelperSubcommand.run(self, setup)
         self.cachemgr = CacheManager(Bcfg2.Options.setup.yum_config,
                                      self.verbosity)
+
+        try:
+            print(json.dumps(self._run(setup, None)))
+        except:  # pylint: disable=W0702
+            self.logger.error("Unexpected error running %s: %s" %
+                              (self.__class__.__name__.lower(),
+                               sys.exc_info()[1]), exc_info=1)
+            print(json.dumps(self.fallback))
+            return 2
+        return 0
 
 
 class Clean(CacheManagerSubcommand):
@@ -374,10 +384,7 @@ class CLI(Bcfg2.Options.CommandRegistry):
     """ The bcfg2-yum-helper CLI """
     options = [
         Bcfg2.Options.PathOption(
-            "-c", "--yum-config", help="Yum config file"),
-        Bcfg2.Options.PositionalArgument(
-            "command", help="Yum helper command",
-            choices=['clean', 'makecache', 'complete', 'get_groups'])]
+            "-c", "--yum-config", help="Yum config file")]
 
     def __init__(self):
         Bcfg2.Options.CommandRegistry.__init__(self)


### PR DESCRIPTION
With the new options code, classes used as the parent argument to register_commands must not access the setup object in their __init__ function, because that object hasn't been prepared yet.  It's best, then, not to have an __init__ function at all.