### PR TITLE
Don't use 'input' function under python2.

### DIFF
--- a/src/lib/Bcfg2/Client/__init__.py
+++ b/src/lib/Bcfg2/Client/__init__.py
@@ -67,7 +67,7 @@ def prompt(msg):
         ans = safe_input(msg)
         return ans in ['y', 'Y']
     except UnicodeEncodeError:
-        ans = input(msg.encode('utf-8'))
+        ans = safe_input(msg.encode('utf-8'))
         return ans in ['y', 'Y']
     except (EOFError, KeyboardInterrupt):
         # handle ^C


### PR DESCRIPTION
If diff output contains non-ascii characters, then the first call to safe_input in prompt() will raise UnicodeEncodeError.  prompt will then use input(), which will fail under python2.

This change uses safe_input() in both cases.