### PR TITLE
Ldap enhancements

### DIFF
--- a/doc/development/caching.txt
+++ b/doc/development/caching.txt
@@ -67,6 +67,9 @@ Currently known caches are:
 | pkg_sets    | <Collection.cachekey>`,               |                                                 | for clients                                          |
 |             | hash of the initial package selection |                                                 |                                                      |
 +-------------+---------------------------------------+-------------------------------------------------+------------------------------------------------------+
+| Ldap,       | Hostname, ``<query name>``            | :func:`processed result of the query            | Cached results from the Ldap queries                 |
+| results,    |                                       | <Bcfg2.Server.Plugins.LdapQuery.process_result>`|                                                      |
++-------------+---------------------------------------+-------------------------------------------------+------------------------------------------------------+
 
 These are enumerated so that they can be expired as needed by other
 plugins or other code points.

--- a/doc/server/plugins/grouping/ldap.txt
+++ b/doc/server/plugins/grouping/ldap.txt
@@ -87,6 +87,26 @@ If you wish, you could customize these values in your ``bcfg2.conf``::
     retries = 3
     retry_delay = 3.0
 
+Caching
++++++++
+
+This module could not know, if a value changed on the LDAP server. So it does not cache
+the results of the LDAP queries by default.
+
+You could enable the cache of the results in your ``bcfg2.conf``:
+
+    [ldap]
+    cache = on
+
+If you enable the caching, you have to expire it manually. This module provides a XML-RPC
+method for this purpose: :func:`Ldap.expire_cache
+<Bcfg2.Server.Plugins.Ldap.expire_cache>`.
+
+Even without enabling caching, the results of the LDAP queries are cached, but are
+discarded before each client run. If you access the Ldap results of different client, you
+may get cached results of the last run of this client. If you do not want this behaviour,
+you can disable the caching completely by setting it to ``off``.
+
 Class reference
 ---------------
 
@@ -251,9 +271,3 @@ Known Issues
 ------------
 
 * At this point there is no support for SSL/TLS.
-* This module could not know, if a value changed on the LDAP server. So it could not
-  expire the client metadata cache sanely.
-  If you are using aggressive caching mode, this plugin will expire the metadata cache
-  for a single client at the start of a client run. If you are using LDAP data from
-  another client in a template, you will probably get the cached values from the last
-  client run of that other client.

--- a/doc/server/plugins/grouping/ldap.txt
+++ b/doc/server/plugins/grouping/ldap.txt
@@ -7,7 +7,7 @@ Ldap
 ====
 
 .. warning::
-    This plugin is considered experimental and has known issues (see below).
+    This plugin is considered experimental.
 
 Purpose
 -------
@@ -115,8 +115,8 @@ LdapConnection
 
 .. class:: LdapConnection
 
-   This class represents an LDAP connection. Every query must be associated with exactly
-   one connection.
+   This class represents an LDAP connection. Every query must be associated
+   with exactly one connection.
 
 .. attribute:: LdapConnection.binddn
 
@@ -132,7 +132,13 @@ LdapConnection
 
 .. attribute:: LdapConnection.port
 
-   Port where LDAP server is listening (defaults to 389).
+   Port where LDAP server is listening (defaults to 389). If you use
+   port 636 this module will use ldaps to connect to the server.
+
+.. attribute:: LdapConnection.uri
+
+   LDAP URI of the LDAP server to connect to. This is prefered over
+   :attr:`LdapConnection.host` and :attr:`LdapConnection.port`.
 
 You may pass any of these attributes as keyword arguments when creating the connection object.
 
@@ -266,8 +272,3 @@ search below that DN.
 You do not need to add all LdapQueries to the ``__queries__`` list. Only add those to
 that list, that should be called automatically and whose results should be added to the
 client metadata.
-
-Known Issues
-------------
-
-* At this point there is no support for SSL/TLS.

--- a/doc/server/plugins/grouping/ldap.txt
+++ b/doc/server/plugins/grouping/ldap.txt
@@ -140,6 +140,17 @@ LdapConnection
    LDAP URI of the LDAP server to connect to. This is prefered over
    :attr:`LdapConnection.host` and :attr:`LdapConnection.port`.
 
+   .. note::
+
+      If you are using ldaps you may have to specify additional options
+      for enabling the certificate validation or setting the path for
+      the trusted certificates with :attr:`LdapConnection.options`.
+
+.. attribute:: LdapConnection.options
+
+   Arbitrary options for the LDAP connection. You should specify it
+   as a dict and use the ``OPT_*`` constants from ``python-ldap``.
+
 You may pass any of these attributes as keyword arguments when creating the connection object.
 
 LdapQuery

--- a/src/lib/Bcfg2/Server/Cache.py
+++ b/src/lib/Bcfg2/Server/Cache.py
@@ -96,15 +96,19 @@ class _Cache(MutableMapping):
         return len(list(iter(self)))
 
     def expire(self, key=None):
-        """ expire all items, or a specific item, from the cache """
+        """ expire all items, or a specific item, from the cache
+
+        :returns: number of expired entries
+        """
+
         if key is None:
-            expire(*self._tags)
+            return expire(*self._tags)
         else:
             tags = self._tags | set([key])
             # py 2.5 doesn't support mixing *args and explicit keyword
             # args
             kwargs = dict(exact=True)
-            expire(*tags, **kwargs)
+            return expire(*tags, **kwargs)
 
     def __repr__(self):
         return repr(dict(self))
@@ -152,7 +156,10 @@ def expire(*tags, **kwargs):
     """ Expire all items, a set of items, or one specific item from
     the cache.  If ``exact`` is set to True, then if the given tag set
     doesn't match exactly one item in the cache, nothing will be
-    expired. """
+    expired.
+
+    :returns: number of expired entries
+    """
     exact = kwargs.pop("exact", False)
     count = 0
     if not tags:
@@ -169,6 +176,8 @@ def expire(*tags, **kwargs):
 
     for hook in _hooks:
         hook(tags, exact, count)
+
+    return count
 
 
 def add_expire_hook(func):

--- a/src/lib/Bcfg2/Server/Plugin/helpers.py
+++ b/src/lib/Bcfg2/Server/Plugin/helpers.py
@@ -1707,13 +1707,14 @@ class OnDemandDict(MutableMapping):
     :func:`Bcfg2.Server.Plugins.Packages.Packages.get_additional_data`;
     see the docstring for that function for details on why.
 
-    Unlike a dict, you should not specify values for the righthand
-    side of this mapping, but functions that get values.  E.g.:
+    Unlike a dict, you can specify values or functions for the
+    righthand side of this mapping. If you specify a function, it will
+    be evaluated, when you access the value for the first time. E.g.:
 
     .. code-block:: python
 
         d = OnDemandDict(foo=load_foo,
-                         bar=lambda: "bar");
+                         bar="bar")
     """
 
     def __init__(self, **getters):
@@ -1722,7 +1723,11 @@ class OnDemandDict(MutableMapping):
 
     def __getitem__(self, key):
         if key not in self._values:
-            self._values[key] = self._getters[key]()
+            if callable(self._getters[key]):
+                self._values[key] = self._getters[key]()
+            else:
+                self._values[key] = self._getters[key]
+
         return self._values[key]
 
     def __setitem__(self, key, getter):

--- a/src/lib/Bcfg2/Server/Plugins/Ldap.py
+++ b/src/lib/Bcfg2/Server/Plugins/Ldap.py
@@ -169,8 +169,8 @@ class Ldap(Bcfg2.Server.Plugin.Plugin,
 class LdapConnection(Debuggable):
     """ Connection to an LDAP server. """
 
-    def __init__(self, host="localhost", port=389, uri=None, binddn=None,
-                 bindpw=None):
+    def __init__(self, host="localhost", port=389, uri=None, options=None,
+                 binddn=None, bindpw=None):
         Debuggable.__init__(self)
 
         if HAS_LDAP:
@@ -181,6 +181,7 @@ class LdapConnection(Debuggable):
         self.host = host
         self.port = port
         self.uri = uri
+        self.options = options
         self.binddn = binddn
         self.bindpw = bindpw
         self.conn = None
@@ -206,6 +207,10 @@ class LdapConnection(Debuggable):
         bind ff both binddn and bindpw are set. """
         self.disconnect()
         self.conn = ldap.initialize(self.get_uri())
+
+        if self.options is not None:
+            for (option, value) in self.options.items():
+                self.conn.set_option(option, value)
 
         if self.binddn is not None and self.bindpw is not None:
             self.conn.simple_bind_s(self.binddn, self.bindpw)

--- a/src/lib/Bcfg2/Server/Plugins/Ldap.py
+++ b/src/lib/Bcfg2/Server/Plugins/Ldap.py
@@ -33,7 +33,8 @@ class ConfigFile(Bcfg2.Server.Plugin.FileBacked):
     def Index(self):
         """ Get the queries from the config file """
         try:
-            module = imp.load_source(safe_module_name('Ldap', self.name),
+            module_name = os.path.splitext(os.path.basename(self.name))[0]
+            module = imp.load_source(safe_module_name('Ldap', module_name),
                                      self.name)
         except:  # pylint: disable=W0702
             err = sys.exc_info()[1]

--- a/src/lib/Bcfg2/Server/Plugins/Ldap.py
+++ b/src/lib/Bcfg2/Server/Plugins/Ldap.py
@@ -84,7 +84,8 @@ class Ldap(Bcfg2.Server.Plugin.Plugin,
             self.logger.error(msg)
             raise Bcfg2.Server.Plugin.PluginInitError(msg)
 
-        self.config = ConfigFile(os.path.join(self.data, 'config.py'))
+        self.config = ConfigFile(os.path.join(self.data, 'config.py'),
+                                 core)
 
     def _execute_query(self, query, metadata):
         try:

--- a/src/lib/Bcfg2/Server/Plugins/Packages/__init__.py
+++ b/src/lib/Bcfg2/Server/Plugins/Packages/__init__.py
@@ -10,7 +10,7 @@ import lxml.etree
 import Bcfg2.Options
 import Bcfg2.Server.Cache
 import Bcfg2.Server.Plugin
-from Bcfg2.Compat import urlopen, HTTPError, URLError, MutableMapping
+from Bcfg2.Compat import urlopen, HTTPError, URLError
 from Bcfg2.Server.Plugins.Packages.Collection import Collection, \
     get_collection_class
 from Bcfg2.Server.Plugins.Packages.PackagesSources import PackagesSources
@@ -34,52 +34,6 @@ class PackagesBackendAction(Bcfg2.Options.ComponentAction):
     bases = ['Bcfg2.Server.Plugins.Packages']
     module = True
     fail_silently = True
-
-
-class OnDemandDict(MutableMapping):
-    """ This maps a set of keys to a set of value-getting functions;
-    the values are populated on-the-fly by the functions as the values
-    are needed (and not before).  This is used by
-    :func:`Bcfg2.Server.Plugins.Packages.Packages.get_additional_data`;
-    see the docstring for that function for details on why.
-
-    Unlike a dict, you should not specify values for for the righthand
-    side of this mapping, but functions that get values.  E.g.:
-
-    .. code-block:: python
-
-        d = OnDemandDict(foo=load_foo,
-                         bar=lambda: "bar");
-    """
-
-    def __init__(self, **getters):
-        self._values = dict()
-        self._getters = dict(**getters)
-
-    def __getitem__(self, key):
-        if key not in self._values:
-            self._values[key] = self._getters[key]()
-        return self._values[key]
-
-    def __setitem__(self, key, getter):
-        self._getters[key] = getter
-
-    def __delitem__(self, key):
-        del self._values[key]
-        del self._getters[key]
-
-    def __len__(self):
-        return len(self._getters)
-
-    def __iter__(self):
-        return iter(self._getters.keys())
-
-    def __repr__(self):
-        rv = dict(self._values)
-        for key in self._getters.keys():
-            if key not in rv:
-                rv[key] = 'unknown'
-        return str(rv)
 
 
 class Packages(Bcfg2.Server.Plugin.Plugin,
@@ -578,7 +532,7 @@ class Packages(Bcfg2.Server.Plugin.Plugin,
 
     def get_additional_data(self, metadata):
         """ Return additional data for the given client.  This will be
-        an :class:`Bcfg2.Server.Plugins.Packages.OnDemandDict`
+        an :class:`Bcfg2.Server.Plugin.OnDemandDict`
         containing two keys:
 
         * ``sources``, whose value is a list of data returned from
@@ -610,7 +564,7 @@ class Packages(Bcfg2.Server.Plugin.Plugin,
             get_collection() until it's absolutely necessary. """
             return self.get_collection(metadata).get_additional_data()
 
-        return OnDemandDict(
+        return Bcfg2.Server.Plugin.OnDemandDict(
             sources=get_sources,
             get_config=lambda: self.get_config)
 


### PR DESCRIPTION
This adds a few more things to the LDAP plugin and removes the issues mentioned in the docs:
- It supports ldaps now, by providing the possibility to set the LDAP URI directly and setting arbitrary options. 
- The plugin does work with all metadata cache modes, because it only caches the available queries in the metadata cache and adds a separate cache for the results. By default it will cache the results until the next client run. But it can be configured by config file, that it should not cache anything (the ldap query is executed on every access) or that it should keep the cache until it is expired manually via XMLRPC. The cache can be expired by query, by hostname or completely.
