### PR TITLE
Client: Fix reporting of modified entries

### DIFF
--- a/src/lib/Bcfg2/Client/__init__.py
+++ b/src/lib/Bcfg2/Client/__init__.py
@@ -10,6 +10,7 @@ import fnmatch
 import logging
 import argparse
 import tempfile
+import copy
 import Bcfg2.Logger
 import Bcfg2.Options
 from Bcfg2.Client import XML
@@ -950,9 +951,10 @@ class Client(object):
                                 if not states[entry]], "Bad")]:
             container = XML.SubElement(stats, ename)
             for item in data:
-                item.set('qtext', '')
-                container.append(item)
-                item.text = None
+                new_item = copy.deepcopy(item)
+                new_item.set('qtext', '')
+                container.append(new_item)
+                new_item.text = None
 
         timeinfo = XML.Element("OpStamps")
         feedback.append(stats)


### PR DESCRIPTION
If the client is using lxml.etree as ElementTree library, it is impossible to a single node two times in an ElementTree. The second append will remove the first insertion. We need to copy the node before appending it into the statistic tree.

The different behavior of the different ElementTree implementations can be checked with the following example scripts:

```python
import xml.etree.ElementTree as ET
e1 = ET.Element('test')
e2 = ET.Element('test2')
e1.append(e2)
e1.append(e2)
print ET.tostring(e1)
```
Output: `<test><test2 /><test2 /></test>`


```python
import lxml.etree as ET
e1 = ET.Element('test')
e2 = ET.Element('test2')
e1.append(e2)
e1.append(e2)
print ET.tostring(e1)
```
Output: `<test><test2/></test>`
