### PR TITLE
doc: Clarification on negated groups

### DIFF
--- a/doc/server/plugins/grouping/metadata.txt
+++ b/doc/server/plugins/grouping/metadata.txt
@@ -175,6 +175,9 @@ groups:
         <Group name="selinux-enabled" negate="true"/>
       </Client>
 
+Negated groups can also be used to declare other Group assignments,
+but not to declare Bundle assignments.
+
 .. note::
 
     Nested Group conditionals, Client tags, and negated Group tags are


### PR DESCRIPTION
From IRC: 
> AlexS[zedat]: This is a known limitation. Bundles can not be inside conditionals in Metadata/groups.xml.