### PR TITLE
travis-ci: Fix installation of dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   - WITH_OPTIONAL_DEPS=no
 install:
   - testsuite/install.sh
-  - pip install --use-mirrors -e .
+  - pip install -e .
 script:
   - nosetests testsuite
 after_failure:

--- a/testsuite/install.sh
+++ b/testsuite/install.sh
@@ -10,13 +10,13 @@ pip install -r testsuite/requirements.txt
 PYVER=$(python -c 'import sys;print(".".join(str(v) for v in sys.version_info[0:2]))')
 
 if [[ ${PYVER:0:1} == "2" && $PYVER != "2.7" ]]; then
-    pip install --use-mirrors unittest2
+    pip install unittest2
 fi
 
 if [[ "$WITH_OPTIONAL_DEPS" == "yes" ]]; then
     sudo apt-get install -y yum libaugeas0 augeas-lenses libacl1-dev libssl-dev
 
-    pip install --use-mirrors PyYAML pyinotify boto pylibacl 'django<1.5' \
+    pip install PyYAML pyinotify boto pylibacl 'django<1.5' \
         Jinja2 mercurial guppy
     easy_install https://fedorahosted.org/released/python-augeas/python-augeas-0.4.1.tar.gz
     if [[ ${PYVER:0:1} == "2" ]]; then

--- a/testsuite/install.sh
+++ b/testsuite/install.sh
@@ -16,9 +16,9 @@ fi
 if [[ "$WITH_OPTIONAL_DEPS" == "yes" ]]; then
     sudo apt-get install -y yum libaugeas0 augeas-lenses libacl1-dev libssl-dev
 
-    pip install PyYAML pyinotify boto pylibacl 'django<1.5' \
-        Jinja2 mercurial guppy
+    pip install PyYAML pyinotify boto pylibacl django Jinja2 mercurial guppy
     easy_install https://fedorahosted.org/released/python-augeas/python-augeas-0.4.1.tar.gz
+
     if [[ ${PYVER:0:1} == "2" ]]; then
         # django supports py3k, but South doesn't, and the django bits
         # in bcfg2 require South


### PR DESCRIPTION
This is just a quick fix: The new version of pip on travis does
fail when using the `--use-mirrors` option (to be fair, the option
was deprecated long time ago).

The real fix will be #297 (once it will be ready to merge).