### PR TITLE
Fix syntax errors in documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: python
-python:
-  - "2.6"
-  - "2.7_with_system_site_packages"
-env:
-  - WITH_OPTIONAL_DEPS=yes
-  - WITH_OPTIONAL_DEPS=no
+matrix:
+  include:
+    - python: "2.6"
+      env: WITH_OPTIONAL_DEPS=no TEST_SPHINX=no
+    - python: "2.6"
+      env: WITH_OPTIONAL_DEPS=yes TEST_SPHINX=no
+    - python: "2.7_with_system_site_packages"
+      env: WITH_OPTIONAL_DEPS=no TEST_SPHINX=no
+    - python: "2.7_with_system_site_packages"
+      env: WITH_OPTIONAL_DEPS=yes TEST_SPHINX=yes
 install:
   - testsuite/install.sh
   - pip install -e .

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -133,7 +133,7 @@ html_theme_options = {
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-html_favicon = 'favicon.ico'
+html_favicon = '_static/favicon.ico'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/doc/development/compat.txt
+++ b/doc/development/compat.txt
@@ -129,7 +129,7 @@ below, since some of these implementations may be feature-incomplete.
 +----------------+--------------------------------+--------------------------------------------+
 | MutableMapping | :class:`UserDict.DictMixin`    | :class:`collections.MutableMapping` (2.6+) |
 +----------------+--------------------------------+--------------------------------------------+
-| literal_eval   | :func:`eval`                   | :func:`ast.literal_eval`(2.6+)             |
+| literal_eval   | :func:`eval`                   | :func:`ast.literal_eval` (2.6+)            |
 +----------------+--------------------------------+--------------------------------------------+
 
 walk_packages

--- a/doc/releases/index.txt
+++ b/doc/releases/index.txt
@@ -11,5 +11,6 @@ Release Announcements
 
    1.4.0pre2
    1.4.0pre1
+   1.3.6
    1.3.5
    1.3.4

--- a/doc/server/plugins/generators/packages.txt
+++ b/doc/server/plugins/generators/packages.txt
@@ -213,7 +213,7 @@ something like this:
     Packages plugin to add recommended packages by adding the
     :xml:attribute:`SourceType:recommended` attribute, e.g.:
 
-    .. code-block:: xml
+    .. code-block:: none
 
         <Source type="apt" recommended="true" ...>
 
@@ -222,9 +222,9 @@ something like this:
              setting the :xml:attribute:`SourceType:essential`
              attribute to *false*:
 
-    .. code-block:: xml
+        .. code-block:: none
 
-        <Source type="apt" essential="false" ...>
+            <Source type="apt" essential="false" ...>
 
 Yum sources can be similarly specified:
 

--- a/doc/server/plugins/structures/bundler/index.txt
+++ b/doc/server/plugins/structures/bundler/index.txt
@@ -269,7 +269,7 @@ or alternately
          <Path name="/etc/bacula/bconsole.conf"/>
          <Path name="/etc/bacula/bacula-fd.conf"/>
          <Path name="/etc/bacula/bacula-sd.conf"/>
-         <py:if="metadata.hostname == 'foo.bar.com'">
+         <py:if test="metadata.hostname == 'foo.bar.com'">
            <Path name="/etc/bacula/bacula-dir.conf"/>
          </py:if>
     </Bundle>

--- a/doc/unsorted/vim_snippet.txt
+++ b/doc/unsorted/vim_snippet.txt
@@ -13,7 +13,7 @@ that allow quick composition of bundles and base files.
 #. Install it using the install instructions (unzip snipMate.zip -d ~/.vim or equivalent, e.g. $HOME\vimfiles on Windows)
 #. Add the following to ``~/.vim/snippets/xml.snippets``
 
-   .. code-block:: cl
+   .. code-block:: none
 
         # Bundle
         snippet <Bundle

--- a/src/lib/Bcfg2/Server/Encryption.py
+++ b/src/lib/Bcfg2/Server/Encryption.py
@@ -176,7 +176,7 @@ def ssl_encrypt(plaintext, passwd, algorithm=None, salt=None):
 def is_encrypted(val):
     """ Make a best guess if the value is encrypted or not.  This just
     checks to see if ``val`` is a base64-encoded string whose content
-    starts with "Salted__", so it may have (rare) false positives.  It
+    starts with "Salted\\_\\_", so it may have (rare) false positives.  It
     will not have false negatives. """
     try:
         return b64decode(val).startswith("Salted__")

--- a/testsuite/Testsrc/test_doc.py
+++ b/testsuite/Testsrc/test_doc.py
@@ -1,0 +1,39 @@
+import os
+import sys
+
+# add all parent testsuite directories to sys.path to allow (most)
+# relative imports in python 2.4
+_path = os.path.dirname(__file__)
+while _path != '/':
+    if os.path.basename(_path).lower().startswith("test"):
+        sys.path.append(_path)
+    if os.path.basename(_path) == "testsuite":
+        break
+    _path = os.path.dirname(_path)
+from common import *
+
+
+try:
+    from sphinx.application import Sphinx
+    HAS_SPHINX = True
+except ImportError:
+    HAS_SPHINX = False
+
+
+TEST_SPHINX = bool(os.environ.get('TEST_SPHINX', 'yes') != 'no')
+
+
+class DocTest(Bcfg2TestCase):
+    top = os.path.join(os.path.dirname(__file__), '..', '..')
+    source_dir = os.path.join(top, 'doc/')
+    doctree_dir = os.path.join(top, 'build', 'doctree')
+
+    @skipUnless(HAS_SPHINX, 'Sphinx not found')
+    @skipUnless(TEST_SPHINX, 'Documentation testing disabled')
+    def test_html_documentation(self):
+        output_dir = os.path.join(self.top, 'build', 'html')
+
+        app = Sphinx(self.source_dir, self.source_dir, output_dir,
+                     self.doctree_dir, buildername='html',
+                     warningiserror=True)
+        app.build(force_all=True)

--- a/testsuite/install.sh
+++ b/testsuite/install.sh
@@ -14,9 +14,10 @@ if [[ ${PYVER:0:1} == "2" && $PYVER != "2.7" ]]; then
 fi
 
 if [[ "$WITH_OPTIONAL_DEPS" == "yes" ]]; then
-    sudo apt-get install -y yum libaugeas0 augeas-lenses libacl1-dev libssl-dev
+    sudo apt-get install -y yum libaugeas0 augeas-lenses libacl1-dev libssl-dev \
+        python-gamin python-selinux
 
-    pip install PyYAML pyinotify boto pylibacl Jinja2 mercurial guppy
+    pip install PyYAML pyinotify boto pylibacl Jinja2 mercurial guppy cherrypy
     easy_install https://fedorahosted.org/released/python-augeas/python-augeas-0.4.1.tar.gz
 
     if [[ ${PYVER:0:1} == "2" ]]; then


### PR DESCRIPTION
This fixes various small syntax errors in the documentation. It also adds a unit test to check for syntax errors and warnings (only enabled for the tests with python2.7 and optional dependencies).