### PR TITLE
travis-ci: Fix installation of dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - testsuite/before_install.sh
 install:
   - testsuite/install.sh
-  - pip install --use-mirrors -e .
+  - pip install -e .
 script:
   - nosetests testsuite
 branches:

--- a/testsuite/install.sh
+++ b/testsuite/install.sh
@@ -2,13 +2,12 @@
 
 # install script for Travis-CI
 
-pip install -r testsuite/requirements.txt --use-mirrors
+pip install -r testsuite/requirements.txt
 
 PYVER=$(python -c 'import sys;print(".".join(str(v) for v in sys.version_info[0:2]))')
 
 if [[ "$WITH_OPTIONAL_DEPS" == "yes" ]]; then
-    pip install --use-mirrors genshi PyYAML pyinotify boto 'django<1.5' \
-        pylibacl
+    pip install genshi PyYAML pyinotify boto 'django<1.5' pylibacl
     easy_install https://fedorahosted.org/released/python-augeas/python-augeas-0.4.1.tar.gz
     if [[ ${PYVER:0:1} == "2" ]]; then
         # django supports py3k, but South doesn't, and the django bits


### PR DESCRIPTION
The new version of pip on travis does fail when using the --use-mirrors
option (to be fair, the option was deprecated long time ago).

This is like #341 but on maint.