### PR TITLE
Fixes for django 1.10

### DIFF
--- a/src/lib/Bcfg2/Reporting/Compat.py
+++ b/src/lib/Bcfg2/Reporting/Compat.py
@@ -13,4 +13,16 @@ try:
     from django.conf.urls.defaults import url, patterns
 except ImportError:
     # Django > 1.6
-    from django.conf.urls import url, patterns
+    from django.conf.urls import url
+
+    try:
+        from django.conf.urls import patterns
+    except:
+        # Django > 1.10
+        def patterns(_prefix, urls):
+            url_list = list()
+            for u in urls:
+                if isinstance(url_tuple, (list, tuple)):
+                    u = url(*u)
+                url_list.append(u)
+            return url_list

--- a/src/lib/Bcfg2/Reporting/urls.py
+++ b/src/lib/Bcfg2/Reporting/urls.py
@@ -48,16 +48,3 @@ urlpatterns += patterns('Bcfg2.Reporting',
         (r'^history/(?P<hostname>[^/|]+)/?$',
             'views.render_history_view', None, 'reports_client_history'),
 )))
-
-    # Uncomment this for admin:
-    #(r'^admin/', include('django.contrib.admin.urls')),
-
-
-## Uncomment this section if using authentication
-#urlpatterns += patterns('',
-#                        (r'^login/$', 'django.contrib.auth.views.login',
-#                         {'template_name': 'auth/login.html'}),
-#                        (r'^logout/$', 'django.contrib.auth.views.logout',
-#                         {'template_name': 'auth/logout.html'})
-#                        )
-

--- a/src/lib/Bcfg2/Reporting/urls.py
+++ b/src/lib/Bcfg2/Reporting/urls.py
@@ -2,6 +2,7 @@ from Bcfg2.Reporting.Compat import url, patterns  # django compat imports
 from django.core.urlresolvers import reverse, NoReverseMatch
 from django.http import HttpResponsePermanentRedirect
 from Bcfg2.Reporting.utils import filteredUrls, paginatedUrls, timeviewUrls
+from Bcfg2.Reporting import views
 
 handler500 = 'Bcfg2.Reporting.views.server_error'
 
@@ -12,39 +13,39 @@ def newRoot(request):
         grid_view = '/grid'
     return HttpResponsePermanentRedirect(grid_view)
 
-urlpatterns = patterns('Bcfg2.Reporting',
+urlpatterns = patterns('',
     (r'^$', newRoot),
 
-    url(r'^manage/?$', 'views.client_manage', name='reports_client_manage'),
-    url(r'^client/(?P<hostname>[^/]+)/(?P<pk>\d+)/?$', 'views.client_detail', name='reports_client_detail_pk'),
-    url(r'^client/(?P<hostname>[^/]+)/?$', 'views.client_detail', name='reports_client_detail'),
-    url(r'^element/(?P<entry_type>\w+)/(?P<pk>\d+)/(?P<interaction>\d+)?/?$', 'views.config_item', name='reports_item'),
-    url(r'^element/(?P<entry_type>\w+)/(?P<pk>\d+)/?$', 'views.config_item', name='reports_item'),
-    url(r'^entry/(?P<entry_type>\w+)/(?P<pk>\w+)/?$', 'views.entry_status', name='reports_entry'),
+    url(r'^manage/?$', views.client_manage, name='reports_client_manage'),
+    url(r'^client/(?P<hostname>[^/]+)/(?P<pk>\d+)/?$', views.client_detail, name='reports_client_detail_pk'),
+    url(r'^client/(?P<hostname>[^/]+)/?$', views.client_detail, name='reports_client_detail'),
+    url(r'^element/(?P<entry_type>\w+)/(?P<pk>\d+)/(?P<interaction>\d+)?/?$', views.config_item, name='reports_item'),
+    url(r'^element/(?P<entry_type>\w+)/(?P<pk>\d+)/?$', views.config_item, name='reports_item'),
+    url(r'^entry/(?P<entry_type>\w+)/(?P<pk>\w+)/?$', views.entry_status, name='reports_entry'),
 )
 
-urlpatterns += patterns('Bcfg2.Reporting',
+urlpatterns += patterns('',
     *timeviewUrls(
-        (r'^summary/?$', 'views.display_summary', None, 'reports_summary'),
-        (r'^timing/?$', 'views.display_timing', None, 'reports_timing'),
-        (r'^common/group/(?P<group>[^/]+)/(?P<threshold>\d+)/?$', 'views.common_problems', None, 'reports_common_problems'),
-        (r'^common/group/(?P<group>[^/]+)+/?$', 'views.common_problems', None, 'reports_common_problems'),
-        (r'^common/(?P<threshold>\d+)/?$', 'views.common_problems', None, 'reports_common_problems'),
-        (r'^common/?$', 'views.common_problems', None, 'reports_common_problems'),
+        (r'^summary/?$', views.display_summary, None, 'reports_summary'),
+        (r'^timing/?$', views.display_timing, None, 'reports_timing'),
+        (r'^common/group/(?P<group>[^/]+)/(?P<threshold>\d+)/?$', views.common_problems, None, 'reports_common_problems'),
+        (r'^common/group/(?P<group>[^/]+)+/?$', views.common_problems, None, 'reports_common_problems'),
+        (r'^common/(?P<threshold>\d+)/?$', views.common_problems, None, 'reports_common_problems'),
+        (r'^common/?$', views.common_problems, None, 'reports_common_problems'),
 ))
 
-urlpatterns += patterns('Bcfg2.Reporting',
+urlpatterns += patterns('',
     *filteredUrls(*timeviewUrls(
-        (r'^grid/?$', 'views.client_index', None, 'reports_grid_view'),
+        (r'^grid/?$', views.client_index, None, 'reports_grid_view'),
         (r'^detailed/?$',
-            'views.client_detailed_list', None, 'reports_detailed_list'),
-        (r'^elements/(?P<item_state>\w+)/?$', 'views.config_item_list', None, 'reports_item_list'),
+            views.client_detailed_list, None, 'reports_detailed_list'),
+        (r'^elements/(?P<item_state>\w+)/?$', views.config_item_list, None, 'reports_item_list'),
 )))
 
-urlpatterns += patterns('Bcfg2.Reporting',
+urlpatterns += patterns('',
     *paginatedUrls( *filteredUrls(
         (r'^history/?$',
-            'views.render_history_view', None, 'reports_history'),
+            views.render_history_view, None, 'reports_history'),
         (r'^history/(?P<hostname>[^/|]+)/?$',
-            'views.render_history_view', None, 'reports_client_history'),
+            views.render_history_view, None, 'reports_client_history'),
 )))

--- a/testsuite/install.sh
+++ b/testsuite/install.sh
@@ -26,7 +26,7 @@ if [[ "$WITH_OPTIONAL_DEPS" == "yes" ]]; then
         if [[ $PYVER != "2.7" ]]; then
             pip install 'django<1.7' 'South<0.8'
         else
-            pip install 'django<1.10'
+            pip install django
         fi
     fi
 fi


### PR DESCRIPTION
Django 1.10 removes the patterns method for building the urlpatterns. This adds a simple fallback method into `Reporting/Compat.py`. 
