### PR TITLE
debian/control: Replace python-support with dh-python

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,8 +17,8 @@ Build-Depends: debhelper (>= 7.0.50~),
 	       python-m2crypto,
 	       python-doc,
 	       python-mock,
-	       python-mock-doc
-Build-Depends-Indep: python-support (>= 0.5.3)
+	       python-mock-doc,
+	       dh-python
 Standards-Version: 3.8.0.0
 Homepage: http://bcfg2.org/
 


### PR DESCRIPTION
According to the [Debian Python FAQ](https://wiki.debian.org/Python/FAQ), python-support has been deprecated in favor of dh-python.