### PR TITLE
testsuite: Fix database tests

### DIFF
--- a/src/lib/Bcfg2/Server/models.py
+++ b/src/lib/Bcfg2/Server/models.py
@@ -4,44 +4,20 @@ import sys
 import logging
 import Bcfg2.Options
 import Bcfg2.Server.Plugins
-from Bcfg2.Compat import walk_packages
 
-LOGGER = logging.getLogger('Bcfg2.Server.models')
+LOGGER = logging.getLogger(__name__)
 
 MODELS = []
 INTERNAL_DATABASE_VERSION = None
 
 
-def _get_all_plugins():
-    rv = []
-    for submodule in walk_packages(path=Bcfg2.Server.Plugins.__path__,
-                                   prefix="Bcfg2.Server.Plugins."):
-        module = submodule[1].rsplit('.', 1)[-1]
-        if module == 'Reporting':
-            # Exclude Reporting plugin. The reporting database
-            # is handled separately in Bcfg2.Reporting.
-            continue
-        if submodule[1] == "Bcfg2.Server.Plugins.%s" % module:
-            # we only include direct children of
-            # Bcfg2.Server.Plugins -- e.g., all_plugins should
-            # include Bcfg2.Server.Plugins.Cfg, but not
-            # Bcfg2.Server.Plugins.Cfg.CfgInfoXML
-            rv.append(module)
-    return rv
-
-
-_ALL_PLUGINS = _get_all_plugins()
-
-
 class _OptionContainer(object):
+    """Options for Bcfg2 database models."""
+
     # we want to provide a different default plugin list --
     # namely, _all_ plugins, so that the database is guaranteed to
     # work, even if /etc/bcfg2.conf isn't set up properly
-    options = [
-        Bcfg2.Options.Option(
-            cf=('server', 'plugins'), type=Bcfg2.Options.Types.comma_list,
-            default=_ALL_PLUGINS, dest="models_plugins",
-            action=Bcfg2.Options.PluginsAction)]
+    options = [Bcfg2.Options.Common.plugins]
 
     @staticmethod
     def options_parsed_hook():
@@ -63,7 +39,7 @@ def load_models(plugins=None):
     global MODELS
 
     if not plugins:
-        plugins = Bcfg2.Options.setup.models_plugins
+        plugins = Bcfg2.Options.setup.plugins
 
     if MODELS:
         # load_models() has been called once, so first unload all of

--- a/testsuite/Testsrc/Testlib/TestServer/TestPlugin/Testhelpers.py
+++ b/testsuite/Testsrc/Testlib/TestServer/TestPlugin/Testhelpers.py
@@ -51,6 +51,7 @@ class TestFunctions(Bcfg2TestCase):
 
 class TestDatabaseBacked(TestPlugin):
     test_obj = DatabaseBacked
+    synced = False
 
     def setUp(self):
         TestPlugin.setUp(self)
@@ -75,6 +76,15 @@ class TestDatabaseBacked(TestPlugin):
 
         setattr(Bcfg2.Options.setup, attr, True)
         self.assertRaises(PluginInitError, self.get_obj, core)
+
+    def syncdb(self, modeltest):
+        """ Given an instance of a :class:`DBModelTestCase` object, sync
+        and clean the database """
+        inst = modeltest(methodName='test_syncdb')
+        if not self.__class__.synced:
+            inst.test_syncdb()
+            self.__class__.synced = True
+        inst.test_cleandb()
 
 
 class TestPluginDatabaseModel(Bcfg2TestCase):

--- a/testsuite/Testsrc/Testlib/TestServer/TestPlugins/TestMetadata.py
+++ b/testsuite/Testsrc/Testlib/TestServer/TestPlugins/TestMetadata.py
@@ -123,7 +123,7 @@ class TestClientVersions(TestDatabaseBacked):
     def setUp(self):
         TestDatabaseBacked.setUp(self)
         self.test_obj = ClientVersions
-        syncdb(TestMetadataDB)
+        self.syncdb(TestMetadataDB)
         for client, version in self.test_clients.items():
             MetadataClientModel(hostname=client, version=version).save()
 
@@ -1252,7 +1252,7 @@ class TestMetadataBase(TestMetadata):
         TestClientRunHooks.setUp(self)
         TestDatabaseBacked.setUp(self)
         Bcfg2.Options.setup.metadata_db = True
-        syncdb(TestMetadataDB)
+        self.syncdb(TestMetadataDB)
 
     def load_clients_data(self, metadata=None, xdata=None):
         if metadata is None:

--- a/testsuite/Testsrc/Testlib/TestServer/TestPlugins/TestProbes.py
+++ b/testsuite/Testsrc/Testlib/TestServer/TestPlugins/TestProbes.py
@@ -201,7 +201,7 @@ group-specific"""
                 assert False, "Strange probe found in get_probe_data() return"
 
 
-class TestProbes(TestPlugin):
+class TestProbes(TestDatabaseBacked):
     test_obj = Probes
 
     test_xdata = lxml.etree.Element("test")
@@ -241,7 +241,7 @@ group:      group:with:colons
             self.datastore = None
             Bcfg2.Options.setup.repository = datastore
 
-    def get_obj(self):
+    def get_obj(self, core=None):
         if not Bcfg2.Options.setup.probes_db:
             # actually use a real datastore so we can read and write
             # probed.xml
@@ -251,7 +251,7 @@ group:      group:with:colons
                 datadir = os.path.join(self.datastore, self.test_obj.name)
                 if not os.path.exists(datadir):
                     os.makedirs(datadir)
-        return TestPlugin.get_obj(self)
+        return TestPlugin.get_obj(self, core)
 
     def test__init(self):
         if Bcfg2.Options.setup.probes_db:

--- a/testsuite/Testsrc/Testlib/TestServer/TestPlugins/TestProbes.py
+++ b/testsuite/Testsrc/Testlib/TestServer/TestPlugins/TestProbes.py
@@ -278,7 +278,7 @@ group:      group:with:colons
     def test_probes_db(self):
         """ Set and retrieve probe data with database enabled """
         Bcfg2.Options.setup.probes_db = True
-        syncdb(TestProbesDB)
+        self.syncdb(TestProbesDB)
         self._perform_tests()
 
     def test_allowed_cgroups(self):

--- a/testsuite/common.py
+++ b/testsuite/common.py
@@ -245,14 +245,6 @@ class DBModelTestCase(Bcfg2TestCase):
             self.assertItemsEqual(list(model.objects.all()), [])
 
 
-def syncdb(modeltest):
-    """ Given an instance of a :class:`DBModelTestCase` object, sync
-    and clean the database """
-    inst = modeltest(methodName='test_syncdb')
-    inst.test_syncdb()
-    inst.test_cleandb()
-
-
 # in order for patchIf() to decorate a function in the same way as
 # patch(), we override the default behavior of __enter__ and __exit__
 # on the _patch() object to basically be noops.

--- a/testsuite/common.py
+++ b/testsuite/common.py
@@ -240,9 +240,9 @@ class DBModelTestCase(Bcfg2TestCase):
             # Create new
             if django.VERSION[0] == 1 and django.VERSION[1] < 7:
                 django.core.management.call_command('syncdb', interactive=False,
-                                                    verbosity=0)
+                                                    verbosity=1)
             django.core.management.call_command('migrate', interactive=False,
-                                                verbosity=0)
+                                                verbosity=1)
 
             # Check if database exists now
             self.assertTrue(os.path.exists(dbfile))


### PR DESCRIPTION
This reverts again the _removed duplicate plugins option_ commit. Sorry for introduction the bug again. I think this was introduced, due to incomplete local tests. The database tests reused the sqlite3 file from earlier tests.

Now the tests remove the old database (with unlink) and recreate it from scratch once per TestCase.