### PR TITLE
bcfg2-admin: pass SSL protocol option for perf and xcmd connections

### DIFF
--- a/src/lib/Bcfg2/Server/Admin/Perf.py
+++ b/src/lib/Bcfg2/Server/Admin/Perf.py
@@ -18,7 +18,8 @@ class Perf(Bcfg2.Server.Admin.Mode):
             'password': Bcfg2.Options.SERVER_PASSWORD,
             'server': Bcfg2.Options.SERVER_LOCATION,
             'user': Bcfg2.Options.CLIENT_USER,
-            'timeout': Bcfg2.Options.CLIENT_TIMEOUT}
+            'timeout': Bcfg2.Options.CLIENT_TIMEOUT,
+            'protocol': Bcfg2.Options.SERVER_PROTOCOL}
         setup = Bcfg2.Options.OptionParser(optinfo)
         setup.parse(sys.argv[1:])
         proxy = Bcfg2.Proxy.ComponentProxy(setup['server'],
@@ -27,7 +28,8 @@ class Perf(Bcfg2.Server.Admin.Mode):
                                            key=setup['key'],
                                            cert=setup['certificate'],
                                            ca=setup['ca'],
-                                           timeout=setup['timeout'])
+                                           timeout=setup['timeout'],
+                                           protocol=setup['protocol'])
         data = proxy.get_statistics()
         for key in sorted(data.keys()):
             output.append(

--- a/src/lib/Bcfg2/Server/Admin/Xcmd.py
+++ b/src/lib/Bcfg2/Server/Admin/Xcmd.py
@@ -18,7 +18,8 @@ class Xcmd(Bcfg2.Server.Admin.Mode):
             'key': Bcfg2.Options.SERVER_KEY,
             'certificate': Bcfg2.Options.CLIENT_CERT,
             'ca': Bcfg2.Options.CLIENT_CA,
-            'timeout': Bcfg2.Options.CLIENT_TIMEOUT}
+            'timeout': Bcfg2.Options.CLIENT_TIMEOUT,
+            'protocol': Bcfg2.Options.SERVER_PROTOCOL}
         setup = Bcfg2.Options.OptionParser(optinfo)
         setup.parse(args)
         Bcfg2.Proxy.RetryMethod.max_retries = 1
@@ -28,7 +29,8 @@ class Xcmd(Bcfg2.Server.Admin.Mode):
                                            key=setup['key'],
                                            cert=setup['certificate'],
                                            ca=setup['ca'],
-                                           timeout=setup['timeout'])
+                                           timeout=setup['timeout'],
+                                           protocol=setup['protocol'])
         if len(setup['args']) == 0:
             self.errExit("Usage: xcmd <xmlrpc method> <optional arguments>")
         cmd = setup['args'][0]

--- a/src/lib/Bcfg2/Server/Plugins/Ohai.py
+++ b/src/lib/Bcfg2/Server/Plugins/Ohai.py
@@ -19,7 +19,7 @@ PROBECODE = """#!/bin/sh
 
 export PATH=$PATH:/sbin:/usr/sbin
 
-if type ohai >& /dev/null; then
+if type ohai >/dev/null 2>&1; then
     ohai
 else
     # an empty dict, so "'foo' in metadata.Ohai" tests succeed


### PR DESCRIPTION
bcfg2-admin xcmd and perf are broken after commit a2b8b3282bc07e1db362d2edd51d2bee3e425d57
Ohai probe is unable to run on Ubuntu/Debian systems with /bin/dash as /bin/sh, due to syntax incompatibility with bash/csh