### PR TITLE
Options: Missing config file is not a fatal error

### DIFF
--- a/src/lib/Bcfg2/Options/Parser.py
+++ b/src/lib/Bcfg2/Options/Parser.py
@@ -302,7 +302,7 @@ class Parser(argparse.ArgumentParser):
 
         # check whether the specified bcfg2.conf exists
         if not self.unit_test and not os.path.exists(bootstrap.config):
-            self.error("Could not read %s" % bootstrap.config)
+            sys.stderr.write("Could not read %s\n" % bootstrap.config)
         self.add_config_file(self.configfile.dest, bootstrap.config,
                              reparse=False)
 

--- a/testsuite/Testsrc/Testlib/TestOptions/TestConfigFiles.py
+++ b/testsuite/Testsrc/Testlib/TestOptions/TestConfigFiles.py
@@ -45,9 +45,10 @@ class TestConfigFiles(OptionTestCase):
         inner1()
 
     @mock.patch("os.path.exists", mock.Mock(return_value=False))
-    def test_no_config_file(self):
+    @make_config()
+    def test_no_config_file(self, config):
         """fail to read config file."""
         try:
-            self.parser.parse()
+            self.parser.parse(['-C', config])
         except SystemExit:
             self.fail('Missing config file should not raise SystemExit')

--- a/testsuite/Testsrc/Testlib/TestOptions/TestConfigFiles.py
+++ b/testsuite/Testsrc/Testlib/TestOptions/TestConfigFiles.py
@@ -47,4 +47,7 @@ class TestConfigFiles(OptionTestCase):
     @mock.patch("os.path.exists", mock.Mock(return_value=False))
     def test_no_config_file(self):
         """fail to read config file."""
-        self.assertRaises(SystemExit, self.parser.parse, [])
+        try:
+            self.parser.parse()
+        except SystemExit:
+            self.fail('Missing config file should not raise SystemExit')


### PR DESCRIPTION
If the config file is not available, it should not be a fatal error,
but bcfg2 should just use the default config values.
