### PR TITLE
doc: Document new behavior from 5a0307fb

### DIFF
--- a/doc/releases/1.4.0pre1.txt
+++ b/doc/releases/1.4.0pre1.txt
@@ -43,6 +43,9 @@ backwards-incompatible user-facing changes
     You can convert your existing decisions using
     ``tools/upgrade/1.4/migrate_decisions.py``.
 
+* The Probe plugin no longer strips probe output. You may need to adjust
+  your probe output if you want trailing whitespace to be removed.
+
 
 deprecated features (will be removed in a future release, likely 1.5)
 ---------------------------------------------------------------------


### PR DESCRIPTION
We no longer strip() the trailing whitespace from Probe output which can
result in different behavior than previous versions.

Signed-off-by: Sol Jerome <sol.jerome@gmail.com>