### PR TITLE
Packages: Cleanup pkgnames

### DIFF
--- a/src/lib/Bcfg2/Server/Plugins/Packages/Apt.py
+++ b/src/lib/Bcfg2/Server/Plugins/Packages/Apt.py
@@ -86,6 +86,7 @@ class AptSource(Source):
         bdeps = dict()
         brecs = dict()
         bprov = dict()
+        self.pkgnames = set()
         self.essentialpkgs = set()
         for fname in self.files:
             if not self.rawurl:

--- a/src/lib/Bcfg2/Server/Plugins/Packages/Pac.py
+++ b/src/lib/Bcfg2/Server/Plugins/Packages/Pac.py
@@ -124,7 +124,8 @@ class PacSource(Source):
         bdeps = {}
         brecs = {}
         bprov = {}
-
+        self.pkgnames = set()
+        self.pacgroups = {}
         for fname in self.files:
             if not self.rawurl:
                 barch = [x for x in fname.split('@') if x in self.arches][0]

--- a/src/lib/Bcfg2/Server/Plugins/Packages/Pkgng.py
+++ b/src/lib/Bcfg2/Server/Plugins/Packages/Pkgng.py
@@ -56,6 +56,7 @@ class PkgngSource(Source):
 
     def read_files(self):
         bdeps = dict()
+        self.pkgnames = set()
         for fname in self.files:
             if not self.rawurl:
                 abi = [x


### PR DESCRIPTION
The pkgnames should be reset before parsing the source files. If a package was
removed for a source, it should be removed from the pkgnames set, too. The
packages plugin should look for the next source containing the package.