### PR TITLE
Client/Proxy.py: Provide more useful error message

### DIFF
--- a/src/lib/Bcfg2/Client/Proxy.py
+++ b/src/lib/Bcfg2/Client/Proxy.py
@@ -1,3 +1,4 @@
+import os.path
 import re
 import sys
 import time
@@ -202,6 +203,8 @@ class SSLHTTPConnection(httplib.HTTPConnection):
             raise Exception("unknown protocol %s" % self.protocol)
         if self.ca:
             other_side_required = ssl.CERT_REQUIRED
+            if not os.path.isfile(self.ca):
+                self.logger.error("CA specified but none found at %s" % self.ca)
         else:
             other_side_required = ssl.CERT_NONE
             self.logger.warning("No ca is specified. Cannot authenticate the "


### PR DESCRIPTION
Previously, having a ca specified in the client bcfg2.conf which pointed
to a file that didn't exist resulted in the following:

    Unknown failure: [Errno 2] No such file or directory (IOError)
    Unknown failure: [Errno 2] No such file or directory (IOError)
    Unknown failure: [Errno 2] No such file or directory (IOError)
    Fatal error: Failed to declare version: Unknown failure: [Errno 2] No such file or directory (IOError)

This commit provides more information about the actual cause of the
issue.

Signed-off-by: Sol Jerome <sol.jerome@gmail.com>