### PR TITLE
Some small fixes for NagiosGen

### DIFF
--- a/doc/server/plugins/generators/nagiosgen.txt
+++ b/doc/server/plugins/generators/nagiosgen.txt
@@ -194,7 +194,4 @@ moderation.
 ``NagiosGen/config.xml`` replaces the files
 ``Properties/NagiosGen.xml`` and ``NagiosGen/parents.xml`` in older
 versions of Bcfg2; your old configs can be migrated using the
-``nagiosgen-convert.py`` tool.  The plugin does contain a
-backwards-compatibility layer for those older config files, but
-``NagiosGen/config.xml`` must exist (even if empty) for the plugin to
-function.
+``nagiosgen-convert.py`` tool.

--- a/src/lib/Bcfg2/Server/Plugins/NagiosGen.py
+++ b/src/lib/Bcfg2/Server/Plugins/NagiosGen.py
@@ -92,7 +92,7 @@ class NagiosGen(Plugin, Generator):
         for host in host_configs:
             host_data.append(open(host, 'r').read())
 
-        group_list = []
+        group_list = ['default']
         for line in "\n".join(host_data).splitlines():
             # only include those groups which are actually used
             if "hostgroup" in line:

--- a/src/lib/Bcfg2/Server/Plugins/NagiosGen.py
+++ b/src/lib/Bcfg2/Server/Plugins/NagiosGen.py
@@ -92,17 +92,15 @@ class NagiosGen(Plugin, Generator):
         for host in host_configs:
             host_data.append(open(host, 'r').read())
 
-        group_list = ['default']
+        used_groups = set(['default'])
         for line in "\n".join(host_data).splitlines():
             # only include those groups which are actually used
             if "hostgroup" in line:
-                group_list += line.split()[1].split(',')
-
-        group_list = list(set(group_list))
+                used_groups.update(line.split()[1].split(','))
 
         for group in group_configs:
             group_name = re.sub("(-group.cfg|.*/(?=[^/]+))", "", group)
-            if group_name in group_list:
+            if group_name in used_groups:
                 groupfile = open(group, 'r')
                 group_data.append(groupfile.read())
                 groupfile.close()


### PR DESCRIPTION
Some small fixes for the NagiosGen plugin:

* Update documentation: The _backwards-compatibility layer_ was removed.
* Always include default group. This should fix #161.
* Small code cleanup. Why should you use a list if you want to have a set?!