### PR TITLE
Fix bcfg2-report-collector for django-1.9

### DIFF
--- a/src/lib/Bcfg2/DBSettings.py
+++ b/src/lib/Bcfg2/DBSettings.py
@@ -143,6 +143,8 @@ def finalize_django_config(opts=None, silent=False):
         setattr(module, name, value)
     try:
         django.conf.settings.configure(**settings)
+        if django.VERSION[0] == 1 and django.VERSION[1] >= 7:
+            django.setup()  # pylint: disable=E1101
     except RuntimeError:
         if not silent:
             logger.warning("Failed to finalize Django settings: %s" %
@@ -204,7 +206,6 @@ def migrate_databases(**kwargs):
     for database in settings['DATABASES']:
         logger.debug("Migrating database %s" % (database))
         if django.VERSION[0] == 1 and django.VERSION[1] >= 7:
-            django.setup()  # pylint: disable=E1101
             if initial_django_migration(database):
                 logger.warning(
                     "No applied django migrations found for database %s. "

--- a/src/lib/Bcfg2/Reporting/Reports.py
+++ b/src/lib/Bcfg2/Reporting/Reports.py
@@ -327,8 +327,6 @@ class CLI(Bcfg2.Options.CommandRegistry):
             components=[self])
         parser.add_options(self.subcommand_options)
         parser.parse()
-        if django.VERSION[0] == 1 and django.VERSION[1] >= 7:
-            django.setup()  # pylint: disable=E1101
 
     def run(self):
         """ Run bcfg2-reports """

--- a/src/lib/Bcfg2/Reporting/Storage/DjangoORM.py
+++ b/src/lib/Bcfg2/Reporting/Storage/DjangoORM.py
@@ -20,11 +20,21 @@ from django.core.cache import cache
 #Used by GetCurrentEntry
 import difflib
 from Bcfg2.Compat import b64decode
-from Bcfg2.Reporting.models import \
-    Interaction, PackageEntry, FilePerms, PathEntry, LinkEntry, \
-    Group, Client, Bundle, TYPE_EXTRA, TYPE_BAD, TYPE_MODIFIED, \
-    FailureEntry, Performance, BaseEntry
 from Bcfg2.Reporting.Compat import transaction
+
+
+def load_django_models():
+    """ Load models for Django after option parsing has completed """
+    # pylint: disable=W0602
+    global Interaction, PackageEntry, FilePerms, PathEntry, LinkEntry, \
+        Group, Client, Bundle, TYPE_EXTRA, TYPE_BAD, TYPE_MODIFIED, \
+        FailureEntry, Performance, BaseEntry
+    # pylint: enable=W0602
+
+    from Bcfg2.Reporting.models import \
+        Interaction, PackageEntry, FilePerms, PathEntry, LinkEntry, \
+        Group, Client, Bundle, TYPE_EXTRA, TYPE_BAD, TYPE_MODIFIED, \
+        FailureEntry, Performance, BaseEntry
 
 
 def get_all_field_names(model):
@@ -45,6 +55,7 @@ class DjangoORM(StorageBase):
             type=Bcfg2.Options.Types.size,
             help='Reporting file size limit',
             default=1024 * 1024)]
+    options_parsed_hook = staticmethod(load_django_models)
 
     def _import_default(self, entry, state, entrytype=None, defaults=None,
                         mapping=None, boolean=None, xforms=None):

--- a/src/lib/Bcfg2/Reporting/Storage/DjangoORM.py
+++ b/src/lib/Bcfg2/Reporting/Storage/DjangoORM.py
@@ -2,24 +2,23 @@
 The base for the original DjangoORM (DBStats)
 """
 
-from lxml import etree
-from datetime import datetime
+import difflib
 import traceback
+from datetime import datetime
 from time import strptime
-import Bcfg2.Options
-import Bcfg2.DBSettings
-from Bcfg2.Compat import md5
-from Bcfg2.Reporting.Storage.base import StorageBase, StorageError
-from Bcfg2.Server.Plugin.exceptions import PluginExecutionError
+from lxml import etree
+
 import django
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
 from django.db.models import FieldDoesNotExist
 from django.core.cache import cache
 
-#Used by GetCurrentEntry
-import difflib
-from Bcfg2.Compat import b64decode
+import Bcfg2.Options
+import Bcfg2.DBSettings
+from Bcfg2.Compat import b64decode, md5
 from Bcfg2.Reporting.Compat import transaction
+from Bcfg2.Reporting.Storage.base import StorageBase, StorageError
+from Bcfg2.Server.Plugin.exceptions import PluginExecutionError
 
 
 def load_django_models():

--- a/src/lib/Bcfg2/Reporting/Storage/DjangoORM.py
+++ b/src/lib/Bcfg2/Reporting/Storage/DjangoORM.py
@@ -20,7 +20,10 @@ from django.core.cache import cache
 #Used by GetCurrentEntry
 import difflib
 from Bcfg2.Compat import b64decode
-from Bcfg2.Reporting.models import *
+from Bcfg2.Reporting.models import \
+    Interaction, PackageEntry, FilePerms, PathEntry, LinkEntry, \
+    Group, Client, Bundle, TYPE_EXTRA, TYPE_BAD, TYPE_MODIFIED, \
+    FailureEntry, Performance, BaseEntry
 from Bcfg2.Reporting.Compat import transaction
 
 

--- a/src/lib/Bcfg2/Reporting/Storage/DjangoORM.py
+++ b/src/lib/Bcfg2/Reporting/Storage/DjangoORM.py
@@ -12,7 +12,6 @@ from Bcfg2.Compat import md5
 from Bcfg2.Reporting.Storage.base import StorageBase, StorageError
 from Bcfg2.Server.Plugin.exceptions import PluginExecutionError
 import django
-from django.core import management
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
 from django.db.models import FieldDoesNotExist
 from django.core.cache import cache

--- a/src/lib/Bcfg2/Server/Admin.py
+++ b/src/lib/Bcfg2/Server/Admin.py
@@ -1228,10 +1228,6 @@ class CLI(Bcfg2.Options.CommandRegistry):
             components=[self])
         parser.add_options(self.subcommand_options)
         parser.parse()
-        if HAS_DJANGO and django.VERSION[0] == 1 and django.VERSION[1] >= 7:
-            # this has been introduced in django 1.7, so pylint fails with
-            # older django releases
-            django.setup()  # pylint: disable=E1101
 
     def run(self):
         """ Run bcfg2-admin """

--- a/src/lib/Bcfg2/Server/Plugins/Metadata.py
+++ b/src/lib/Bcfg2/Server/Plugins/Metadata.py
@@ -21,29 +21,26 @@ from Bcfg2.Compat import MutableMapping, all, any, wraps
 # pylint: enable=W0622
 from Bcfg2.version import Bcfg2VersionInfo
 
+try:
+    from django.db import models
+    HAS_DJANGO = True
+except ImportError:
+    HAS_DJANGO = False
+
 # pylint: disable=C0103
 ClientVersions = None
 MetadataClientModel = None
 # pylint: enable=C0103
-HAS_DJANGO = False
 
 
 def load_django_models():
     """ Load models for Django after option parsing has completed """
     # pylint: disable=W0602
-    global MetadataClientModel, ClientVersions, HAS_DJANGO
+    global MetadataClientModel, ClientVersions
     # pylint: enable=W0602
 
-    try:
-        import django
-        from django.db import models
-        HAS_DJANGO = True
-    except ImportError:
-        HAS_DJANGO = False
+    if not HAS_DJANGO:
         return
-
-    if django.VERSION[0] == 1 and django.VERSION[1] >= 7:
-        django.setup()  # pylint: disable=E1101
 
     class MetadataClientModel(models.Model,  # pylint: disable=W0621
                               Bcfg2.Server.Plugin.PluginDatabaseModel):

--- a/src/lib/Bcfg2/Server/Plugins/Probes.py
+++ b/src/lib/Bcfg2/Server/Plugins/Probes.py
@@ -15,6 +15,12 @@ import Bcfg2.Server.FileMonitor
 from Bcfg2.Logger import Debuggable
 from Bcfg2.Server.Statistics import track_statistics
 
+try:
+    from django.db import models
+    HAS_DJANGO = True
+except ImportError:
+    HAS_DJANGO = False
+
 HAS_DJANGO = False
 # pylint: disable=C0103
 ProbesDataModel = None
@@ -25,19 +31,11 @@ ProbesGroupsModel = None
 def load_django_models():
     """ Load models for Django after option parsing has completed """
     # pylint: disable=W0602
-    global ProbesDataModel, ProbesGroupsModel, HAS_DJANGO
+    global ProbesDataModel, ProbesGroupsModel
     # pylint: enable=W0602
 
-    try:
-        import django
-        from django.db import models
-        HAS_DJANGO = True
-    except ImportError:
-        HAS_DJANGO = False
+    if not HAS_DJANGO:
         return
-
-    if django.VERSION[0] == 1 and django.VERSION[1] >= 7:
-        django.setup()  # pylint: disable=E1101
 
     class ProbesDataModel(models.Model,  # pylint: disable=W0621,W0612
                           Bcfg2.Server.Plugin.PluginDatabaseModel):


### PR DESCRIPTION
This should fix the bcfg2-report-collector for django-1.9 (#357). The import in `DjangoORM.py` is a bit messy, but it works.

This also removes all calls to `django.setup()` but one. The new call in `DBSettings.py` is ideal because all modules using django have to call the `django.conf.settings.configure(..)` from there anyway. I cannot remember why we did not call `django.setup()` there in the first place.
