### PR TITLE
testsuite: Use python-augeas from PyPI with pip

### DIFF
--- a/testsuite/install.sh
+++ b/testsuite/install.sh
@@ -7,8 +7,8 @@ pip install -r testsuite/requirements.txt
 PYVER=$(python -c 'import sys;print(".".join(str(v) for v in sys.version_info[0:2]))')
 
 if [[ "$WITH_OPTIONAL_DEPS" == "yes" ]]; then
-    pip install genshi PyYAML pyinotify boto 'django<1.5' pylibacl
-    easy_install https://fedorahosted.org/released/python-augeas/python-augeas-0.4.1.tar.gz
+    pip install genshi PyYAML pyinotify boto 'django<1.5' pylibacl python-augeas
+
     if [[ ${PYVER:0:1} == "2" ]]; then
         # django supports py3k, but South doesn't, and the django bits
         # in bcfg2 require South


### PR DESCRIPTION
fedorahosted.org was retired on March 1st, 2017. So we need to pull
python-augeas from anywhere else, let's simply install it with pip
from PyPI.