### PR TITLE
testsuite: Use python-augeas from PyPI with pip

### DIFF
--- a/testsuite/install.sh
+++ b/testsuite/install.sh
@@ -17,8 +17,7 @@ if [[ "$WITH_OPTIONAL_DEPS" == "yes" ]]; then
     sudo apt-get install -y yum libaugeas0 augeas-lenses libacl1-dev libssl-dev \
         python-gamin python-selinux
 
-    pip install PyYAML pyinotify boto pylibacl Jinja2 mercurial guppy cherrypy
-    easy_install https://fedorahosted.org/released/python-augeas/python-augeas-0.4.1.tar.gz
+    pip install PyYAML pyinotify boto pylibacl Jinja2 mercurial guppy cherrypy python-augeas
 
     if [[ ${PYVER:0:1} == "2" ]]; then
         pip install cheetah m2crypto


### PR DESCRIPTION
fedorahosted.org was retired on March 1st, 2017. So we need to pull
python-augeas from anywhere else, let's simply install it with pip
from PyPI.

(Same as #379, but for master.)