### PR TITLE
Fix multiline scripts in bcfg2-info debug mode

### DIFF
--- a/src/lib/Bcfg2/Server/Info.py
+++ b/src/lib/Bcfg2/Server/Info.py
@@ -143,9 +143,7 @@ class Debug(InfoCmd):
         if setup.cmd_list:
             console = InteractiveConsole(locals())
             for command in setup.cmd_list.readlines():
-                command = command.strip()
-                if command:
-                    console.push(command)
+                console.push(command.rstrip())
         if not setup.non_interactive:
             print("Dropping to interpreter; press ^D to resume")
             self.interpreters[setup.interpreter](self.core.get_locals())


### PR DESCRIPTION
This should allow to execute python scripts with indentation through bcfg2-info debug command.

(This is #329 rebased on master.)