### PR TITLE
Server/Info: Fix encoding declaration

### DIFF
--- a/src/lib/Bcfg2/Server/Info.py
+++ b/src/lib/Bcfg2/Server/Info.py
@@ -1,5 +1,5 @@
-""" Subcommands and helpers for bcfg2-info """
 # -*- coding: utf-8 -*-
+""" Subcommands and helpers for bcfg2-info """
 
 import os
 import sys


### PR DESCRIPTION
It seems to be, that there must not be any Python statement before the
magic comment.