### PR TITLE
Probes: Remove wrong line

### DIFF
--- a/src/lib/Bcfg2/Server/Plugins/Probes.py
+++ b/src/lib/Bcfg2/Server/Plugins/Probes.py
@@ -21,7 +21,6 @@ try:
 except ImportError:
     HAS_DJANGO = False
 
-HAS_DJANGO = False
 # pylint: disable=C0103
 ProbesDataModel = None
 ProbesGroupsModel = None


### PR DESCRIPTION
This line brakes django detection for the Probes! It resets the global
variable just after the detection. This line was left while changing
the placement of the detection in fa0d86aba32c40d829f9f94411403221a48283e8.