### PR TITLE
Add rudimentary windows support for bcfg2

### DIFF
--- a/src/lib/Bcfg2/Client/Tools/WinAction.py
+++ b/src/lib/Bcfg2/Client/Tools/WinAction.py
@@ -1,0 +1,79 @@
+"""WinAction driver"""
+import subprocess
+
+import Bcfg2.Client.Tools
+from Bcfg2.Utils import safe_input
+
+
+class WinAction(Bcfg2.Client.Tools.Tool):
+    """Implement Actions"""
+    name = 'WinAction'
+    __handles__ = [('Action', None)]
+    __req__ = {'Action': ['name', 'timing', 'when', 'command', 'status']}
+
+    def RunAction(self, entry):
+        """This method handles command execution and status return."""
+        shell = True
+        shell_string = ''
+        if entry.get('shell', 'false') == 'true':
+            shell = True
+            shell_string = '(in shell) '
+
+        if not Bcfg2.Options.setup.dry_run:
+            if Bcfg2.Options.setup.interactive:
+                prompt = ('Run Action %s%s, %s: (y/N): ' %
+                          (shell_string, entry.get('name'),
+                           entry.get('command')))
+                ans = safe_input(prompt)
+                if ans not in ['y', 'Y']:
+                    return False
+            if False:
+                if entry.get('build', 'true') == 'false':
+                    self.logger.debug("Action: Deferring execution of %s due "
+                                      "to build mode" % entry.get('command'))
+                    return False
+            self.logger.debug("Running Action %s %s" %
+                              (shell_string, entry.get('name')))
+            rv = self.cmd.run(entry.get('command'), shell=shell,
+                              stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE,
+                              close_fds=False)
+            self.logger.debug("Action: %s got return code %s" %
+                              (entry.get('command'), rv.retval))
+            entry.set('rc', str(rv.retval))
+            return entry.get('status', 'check') == 'ignore' or rv.success
+        else:
+            self.logger.debug("In dryrun mode: not running action: %s" %
+                              (entry.get('name')))
+            return False
+
+    def VerifyAction(self, dummy, _):
+        """Actions always verify true."""
+        return True
+
+    def InstallAction(self, entry):
+        """Run actions as pre-checks for bundle installation."""
+        if entry.get('timing') != 'post':
+            return self.RunAction(entry)
+        return True
+
+    def BundleUpdated(self, bundle):
+        """Run postinstalls when bundles have been updated."""
+        states = dict()
+        for action in bundle.findall("Action"):
+            if action.get('timing') in ['post', 'both']:
+                if not self._install_allowed(action):
+                    continue
+                states[action] = self.RunAction(action)
+        return states
+
+    def BundleNotUpdated(self, bundle):
+        """Run Actions when bundles have not been updated."""
+        states = dict()
+        for action in bundle.findall("Action"):
+            if (action.get('timing') in ['post', 'both'] and
+                    action.get('when') != 'modified'):
+                if not self._install_allowed(action):
+                    continue
+                states[action] = self.RunAction(action)
+        return states

--- a/src/lib/Bcfg2/Client/Tools/WinFS.py
+++ b/src/lib/Bcfg2/Client/Tools/WinFS.py
@@ -1,0 +1,178 @@
+"""All Windows Type client support for Bcfg2."""
+import sys
+import os
+import stat
+import tempfile
+import Bcfg2.Options
+import Bcfg2.Client.Tools
+
+
+class WinFS(Bcfg2.Client.Tools.Tool):
+    """Windows File support code."""
+    name = 'WinFS'
+    __handles__ = [('Path', 'file')]
+
+    def __init__(self, config):
+        Bcfg2.Client.Tools.Tool.__init__(self, config)
+        self.__req__ = dict(Path=dict())
+        self.__req__['Path']['file'] = ['name', 'mode', 'owner', 'group']
+    
+    def _getFilePath(self, entry):
+        filePath = os.path.expandvars(os.path.normpath(entry.get('name')[1:]))
+        if(not filePath[1] == ':'):
+            self.logger.info("Skipping \"%s\" because it doesnt look like a Windows Path" % filePath)
+            return False
+        return filePath
+        
+    def VerifyPath(self, entry, _):
+        """Path always verify true."""
+        filePath = self._getFilePath(entry)
+        if(not filePath):
+            return False
+        ondisk = self._exists(filePath)
+        tempdata, is_binary = self._get_data(entry)
+        if isinstance(tempdata, str) and str != unicode:
+            tempdatasize = len(tempdata)
+        else:
+            tempdatasize = len(tempdata.encode(Bcfg2.Options.setup.encoding))
+
+        different = False
+        content = None
+        if not ondisk:
+            # first, see if the target file exists at all; if not,
+            # they're clearly different
+            different = True
+            content = ""
+        elif tempdatasize != ondisk[stat.ST_SIZE]:
+            # next, see if the size of the target file is different
+            # from the size of the desired content
+            different = True
+        else:
+            # finally, read in the target file and compare them
+            # directly. comparison could be done with a checksum,
+            # which might be faster for big binary files, but slower
+            # for everything else
+            try:
+                content = open(filePath).read()
+            except UnicodeDecodeError:
+                content = open(filePath,
+                               encoding=Bcfg2.Options.setup.encoding).read()
+            except IOError:
+                self.logger.error("Windows: Failed to read %s: %s" %
+                                  (filePath, sys.exc_info()[1]))
+                return False
+            different = str(content) != str(tempdata)
+        return not different
+        
+    def InstallPath(self, entry):
+        """Install device entries."""
+        filePath = self._getFilePath(entry)
+
+        if not filePath:
+            return False
+        
+        self.logger.debug("Installing: " + filePath)
+        if not os.path.exists(os.path.dirname(filePath)):
+            if not self._makedirs(path=filePath):
+                return False
+        newfile = self._write_tmpfile(entry, filePath)
+        if not newfile:
+            return False
+        rv = True
+        if not self._rename_tmpfile(newfile, filePath):
+            return False
+
+        return rv
+
+    def _makedirs(self, path):
+        """ os.makedirs helpfully creates all parent directories for us."""
+        created = []
+        cur = path
+        #while cur and cur != '/':
+        #    if not os.path.exists(cur):
+        #        created.append(cur)
+        #    cur = os.path.dirname(cur)
+        rv = True
+        try:
+            os.makedirs(os.path.dirname(path))
+        except OSError:
+            err = sys.exc_info()[1]
+            self.logger.error('Windows: Failed to create directory %s: %s' %
+                              (path, err))
+            rv = False
+        return rv
+
+    def _write_tmpfile(self, entry, filePath):
+        """ Write the file data to a temp file """
+        filedata = self._get_data(entry)[0]
+        # get a temp file to write to that is in the same directory as
+        # the existing file in order to preserve any permissions
+        # protections on that directory, and also to avoid issues with
+        # /tmp set nosetuid while creating files that are supposed to
+        # be setuid
+        try:
+            (newfd, newfile) = \
+                tempfile.mkstemp(prefix=os.path.basename(filePath),
+                                 dir=os.path.dirname(filePath))
+        except OSError:
+            err = sys.exc_info()[1]
+            self.logger.error("Windows: Failed to create temp file in %s: %s" % (filePath, err))
+            return False
+        try:
+            if isinstance(filedata, str) and str != unicode:
+                os.fdopen(newfd, 'w').write(filedata)
+            else:
+                os.fdopen(newfd, 'wb').write(
+                    filedata.encode(Bcfg2.Options.setup.encoding))
+        except (OSError, IOError):
+            err = sys.exc_info()[1]
+            self.logger.error("Windows: Failed to open temp file %s for writing "
+                              "%s: %s" %
+                              (newfile, filePath, err))
+            return False
+        return newfile
+
+    def _get_data(self, entry):
+        """ Get a tuple of (<file data>, <is binary>) for the given entry """
+        is_binary = entry.get('encoding', 'ascii') == 'base64'
+        if entry.get('empty', 'false') == 'true' or not entry.text:
+            tempdata = ''
+        elif is_binary:
+            tempdata = b64decode(entry.text)
+        else:
+            tempdata = entry.text
+            if isinstance(tempdata, unicode) and unicode != str:
+                try:
+                    tempdata = tempdata.encode(Bcfg2.Options.setup.encoding)
+                except UnicodeEncodeError:
+                    err = sys.exc_info()[1]
+                    self.logger.error("Windows: Error encoding file %s: %s" %
+                                      (entry.get('name'), err))
+        return (tempdata, is_binary)
+        
+    def _rename_tmpfile(self, newfile, filePath):
+        """ Rename the given file to the appropriate filename for entry """
+        try:
+            if(os.path.isfile(filePath)):
+                os.unlink(filePath)
+            os.rename(newfile, filePath)
+            return True
+        except OSError:
+            err = sys.exc_info()[1]
+            self.logger.error("Windows: Failed to rename temp file %s to %s: %s"
+                              % (newfile, filePath, err))
+            try:
+                os.unlink(newfile)
+            except OSError:
+                err = sys.exc_info()[1]
+                self.logger.error("Windows: Could not remove temp file %s: %s" %
+                                  (newfile, err))
+            return False
+            
+    def _exists(self, filePath):
+        """ check for existing paths and optionally remove them.  if
+        the path exists, return the lstat of it """
+        try:
+            return os.lstat(filePath)
+        except OSError:
+            return None

--- a/src/lib/Bcfg2/Client/Tools/WinService.py
+++ b/src/lib/Bcfg2/Client/Tools/WinService.py
@@ -1,0 +1,87 @@
+"""WinService support for Bcfg2."""
+
+import glob
+import re
+import subprocess
+
+import Bcfg2.Client.Tools
+import Bcfg2.Client.XML
+
+
+class WinService(Bcfg2.Client.Tools.SvcTool):
+    """WinService service support for Bcfg2."""
+    name = 'WinService'
+    __handles__ = [('Service', 'windows')]
+    __req__ = {'Service': ['name', 'status']}
+
+    def get_svc_command(self, service, action):
+        return "powershell.exe %s-Service %s" % (action, service.get('name'))
+
+    def VerifyService(self, entry, _):
+        """Verify Service status for entry
+        """
+
+        if entry.get('status') == 'ignore':
+            return True
+
+        if entry.get('parameters'):
+            params = entry.get('parameters')
+        else:
+            params = ''
+
+        try:
+            output = self.cmd.run('powershell.exe (Get-Service %s).Status' %
+                                  (entry.get('name')),
+                                  stdout=subprocess.PIPE,
+                                  stderr=subprocess.PIPE,
+                                  close_fds=False).stdout.splitlines()[0]
+        except IndexError:
+            self.logger.error("Service %s not an Windows service" %
+                              entry.get('name'))
+            return False
+
+        
+        if output is None:
+            # service does not exist
+            entry.set('current_status', 'off')
+            status = False
+        elif output.lower() == 'running':
+            # service is running
+            entry.set('current_status', 'on')
+            if entry.get('status') == 'off':
+                status = False
+            else:
+                status = True
+        else:
+            # service is not running
+            entry.set('current_status', 'off')
+            if entry.get('status') == 'on':
+                status = False
+            else:
+                status = True
+
+        return status
+
+    def InstallService(self, entry):
+        """Install Service for entry."""
+        if entry.get('status') == 'on':
+            cmd = "start"
+        elif entry.get('status') == 'off':
+            cmd = "stop"
+        return self.cmd.run(self.get_svc_command(entry, cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=False).success
+        
+    def restart_service(self, service):
+        """Restart a service.
+
+        :param service: The service entry to modify
+        :type service: lxml.etree._Element
+        :returns: Bcfg2.Utils.ExecutorResult - The return value from
+                  :class:`Bcfg2.Utils.Executor.run`
+        """
+        self.logger.debug('Restarting service %s' % service.get('name'))
+        restart_target = service.get('target', 'restart')
+        return self.cmd.run(self.get_svc_command(service, restart_target), stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=False)
+
+    def FindExtra(self):
+        """Locate extra Windows services."""
+        return []

--- a/src/lib/Bcfg2/Client/__init__.py
+++ b/src/lib/Bcfg2/Client/__init__.py
@@ -4,7 +4,6 @@ import os
 import sys
 import stat
 import time
-import fcntl
 import socket
 import fnmatch
 import logging
@@ -13,6 +12,10 @@ import tempfile
 import copy
 import Bcfg2.Logger
 import Bcfg2.Options
+if os.name == 'posix':
+    import fcntl
+elif os.name == 'nt':
+    import subprocess
 from Bcfg2.Client import XML
 from Bcfg2.Client import Proxy
 from Bcfg2.Client import Tools
@@ -196,7 +199,10 @@ class Client(object):
         self.logger.info("Running probe %s" % name)
         ret = XML.Element("probe-data", name=name, source=probe.get('source'))
         try:
-            scripthandle, scriptname = tempfile.mkstemp()
+            fileending = ''
+            if os.name == 'nt':
+                (interpreter, fileending) = probe.attrib.get('interpreter').split('*')
+            scripthandle, scriptname = tempfile.mkstemp(suffix = fileending)
             if sys.hexversion >= 0x03000000:
                 script = os.fdopen(scripthandle, 'w',
                                    encoding=Bcfg2.Options.setup.encoding)
@@ -210,11 +216,17 @@ class Client(object):
                 else:
                     script.write(probe.text.encode('utf-8'))
                 script.close()
-                os.chmod(scriptname,
-                         stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH |
-                         stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH |
-                         stat.S_IWUSR)  # 0755
-                rv = self.cmd.run(scriptname)
+                if os.name == 'nt':
+                    rv = self.cmd.run([interpreter, scriptname],
+                                         stdout=subprocess.PIPE,
+                                         stderr=subprocess.PIPE,
+                                         close_fds=False)
+                else:
+                    os.chmod(scriptname,
+                             stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH |
+                             stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH |
+                             stat.S_IWUSR)  # 0755
+                    rv = self.cmd.run(scriptname)
                 if rv.stderr:
                     self.logger.warning("Probe %s has error output: %s" %
                                         (name, rv.stderr))
@@ -409,15 +421,13 @@ class Client(object):
         if not Bcfg2.Options.setup.no_lock:
             # check lock here
             try:
-                lockfile = open(Bcfg2.Options.setup.lockfile, 'w')
-                if locked(lockfile.fileno()):
+                if locked(Bcfg2.Options.setup.lockfile):
                     self.fatal_error("Another instance of Bcfg2 is running. "
                                      "If you want to bypass the check, run "
                                      "with the -O/--no-lock option")
             except SystemExit:
                 raise
             except:
-                lockfile = None
                 self.logger.error("Failed to open lockfile %s: %s" %
                                   (Bcfg2.Options.setup.lockfile,
                                    sys.exc_info()[1]))
@@ -427,10 +437,14 @@ class Client(object):
 
         if not Bcfg2.Options.setup.no_lock:
             # unlock here
-            if lockfile:
+            if os.path.isfile(Bcfg2.Options.setup.lockfile):
                 try:
-                    fcntl.lockf(lockfile.fileno(), fcntl.LOCK_UN)
-                    os.remove(Bcfg2.Options.setup.lockfile)
+                    if os.name == 'nt':
+                        os.unlink(Bcfg2.Options.setup.lockfile)
+                    else:
+                        lockfile = open(file, 'w')
+                        fcntl.lockf(lockfile.fileno(), fcntl.LOCK_UN)
+                        os.remove(Bcfg2.Options.setup.lockfile)
                 except OSError:
                     self.logger.error("Failed to unlock lockfile %s" %
                                       lockfile.name)

--- a/src/lib/Bcfg2/Logger.py
+++ b/src/lib/Bcfg2/Logger.py
@@ -1,14 +1,15 @@
 """Bcfg2 logging support"""
-
+import os
 import copy
-import fcntl
 import logging
 import logging.handlers
 import math
 import socket
 import struct
 import sys
-import termios
+if os.name != 'nt':
+    import fcntl
+    import termios
 import Bcfg2.Options
 
 logging.raiseExceptions = 0

--- a/src/lib/Bcfg2/Options/Types.py
+++ b/src/lib/Bcfg2/Options/Types.py
@@ -3,8 +3,9 @@ with the :class:`Bcfg2.Options.Option` constructor. """
 
 import os
 import re
-import pwd
-import grp
+if os.name != 'nt':
+    import pwd
+    import grp
 from Bcfg2.Compat import literal_eval
 
 _COMMA_SPLIT_RE = re.compile(r'\s*,\s*')


### PR DESCRIPTION
This pull request adds rudimentary windows support to bcfg2. The most changes are in the probe and the locking sections:

-Probes
        The shebangline of the probes have to be in the format "#!C:\Path\to\interpreter.exe*.fileending" because windows refuses to run files without an fileending. An example shebangline would be "#!C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe*.ps1"

-Locking
        Unfortunately windows has no fcntl so that locking under windows is done by writing the pid into the lockfile

-Tools
        For managing windows i have written three Tools: WinAction, WinFS, WinService
        -WinAction handles the default Action entrys. Example entry <Action name='test' command="echo test > C:\test.txt" timing="post" when="always" status="check"/>
        -WinFS handles Path entrys. Example entrys "<Path name='/%ProgramFiles%/test/test.txt'/>" or "<Path name='/C:/test.txt'/>". Currently the options owner, group and mode are ignored completly.
        -WinService handles service entrys and starts, stops or restarts the services via powershell. Example Entry: "<Service name='icinga2' type='windows' status="on" />"