### PR TITLE
Use older mercurial for python2.6

### DIFF
--- a/testsuite/install.sh
+++ b/testsuite/install.sh
@@ -17,15 +17,15 @@ if [[ "$WITH_OPTIONAL_DEPS" == "yes" ]]; then
     sudo apt-get install -y yum libaugeas0 augeas-lenses libacl1-dev libssl-dev \
         python-gamin python-selinux
 
-    pip install PyYAML pyinotify boto pylibacl Jinja2 mercurial guppy cherrypy python-augeas
+    pip install PyYAML pyinotify boto pylibacl Jinja2 guppy cherrypy python-augeas
 
     if [[ ${PYVER:0:1} == "2" ]]; then
         pip install cheetah m2crypto
 
         if [[ $PYVER != "2.7" ]]; then
-            pip install 'django<1.7' 'South<0.8'
+            pip install 'django<1.7' 'South<0.8' 'mercurial<4.3'
         else
-            pip install django
+            pip install django mercurial
         fi
     fi
 fi


### PR DESCRIPTION
> Mercurial 4.2.2 is the last release to support Python 2.6.
> Use this if you need to run Mercurial on old platforms and
> you cannot update your Python installation.

See also: https://www.mercurial-scm.org/wiki/SupportedPythonVersions