### PR TITLE
doc: Remove support for docutils-0.4

### DIFF
--- a/doc/exts/xmlschema.py
+++ b/doc/exts/xmlschema.py
@@ -70,10 +70,9 @@ import lxml.etree
 from docutils import nodes
 from sphinx import addnodes, roles
 from docutils.statemachine import ViewList
-from docutils.parsers.rst import directives
+from docutils.parsers.rst import Directive, directives
 from sphinx.util.nodes import make_refnode, split_explicit_title, \
     nested_parse_with_titles
-from sphinx.util.compat import Directive
 from sphinx.domains import ObjType, Domain
 
 try:

--- a/src/lib/Bcfg2/Options/Options.py
+++ b/src/lib/Bcfg2/Options/Options.py
@@ -363,7 +363,7 @@ class RepositoryMacroOption(Option):
     def transform_value(self, value):
         """transform the value after macro expansion.
 
-         this can be overridden to further transform the value set by
+        this can be overridden to further transform the value set by
         the user *after* macros are expanded, but before the user's
         ``type`` function is applied. principally exists for
         PathOption to canonicalize the path.


### PR DESCRIPTION
The compat class from sphinx for "Directive" was deprecated and removed in the
current sphinx version. So we should use the class from docutils directly.

You will need at least docutils-0.5 (from 2008) to build the documentation.