### PR TITLE
Added metadata.Vars as quick access to Property like attributes

### DIFF
--- a/src/lib/Bcfg2/Server/Plugins/Vars.py
+++ b/src/lib/Bcfg2/Server/Plugins/Vars.py
@@ -1,34 +1,35 @@
 """ Support for client ACLs based on IP address and client metadata """
 
+import copy
 import os
 import sys
-import Bcfg2.Server.Plugin
+
 import lxml
-import copy
-from Bcfg2.Server.Plugin import PluginExecutionError
+
+import Bcfg2.Server.Plugin
 from Bcfg2.Server.Cache import Cache
+from Bcfg2.Server.Plugin import PluginExecutionError
 
 
 class VarsFile(Bcfg2.Server.Plugin.StructFile):
     """ representation of Vars vars.xml """
     def __init__(self, name, core, should_monitor=False):
-        """
-        :param name: The filename of this vars file.
-        :type name: string
-        :param core: The Bcfg2.Server.Core initializing the Vars plugin
-        :type core: Bcfg2.Server.Core
-        """
         Bcfg2.Server.Plugin.StructFile.__init__(self, name,
                                                 should_monitor=should_monitor)
         self.name = name
         self.core = core
         self.cache = Cache("Vars")
 
+    __init__.__doc__ = Bcfg2.Server.Plugin.StructFile.__init__.__doc__
+
     def Index(self):
         Bcfg2.Server.Plugin.StructFile.Index(self)
         self.cache.clear()
 
+    Index.__doc__ = Bcfg2.Server.Plugin.StructFile.Index.__doc__
+
     def get_vars(self, metadata):
+        """ gets all var tags from the vars.xml """
         if metadata.hostname in self.cache:
             self.debug_log("Vars: Found cached vars for %s." % metadata.hostname)
             return copy.copy(self.cache[metadata.hostname])
@@ -65,8 +66,9 @@ class VarsFile(Bcfg2.Server.Plugin.StructFile):
                                        "bcfg2-lint for more details" %
                                        self.name)
 
+
 class Vars(Bcfg2.Server.Plugin.Plugin,
-          Bcfg2.Server.Plugin.Connector):
+           Bcfg2.Server.Plugin.Connector):
     """ add additional info to the metadata object based on entries in the vars.xml """
 
     def __init__(self, core):
@@ -76,10 +78,14 @@ class Vars(Bcfg2.Server.Plugin.Plugin,
                                   core,
                                   should_monitor=True)
 
+    __init__.__doc__ = Bcfg2.Server.Plugin.Plugin.__init__.__doc__
+
     def get_additional_data(self, metadata):
-        """ """
         self.debug_log("Vars: Getting vars for %s" % metadata.hostname)
         return self.vars_file.get_vars(metadata)
+
+    get_additional_data.__doc__ = \
+        Bcfg2.Server.Plugin.Connector.get_additional_data.__doc__
 
     def set_debug(self, debug):
         rv = Bcfg2.Server.Plugin.Plugin.set_debug(self, debug)

--- a/src/lib/Bcfg2/Server/Plugins/Vars.py
+++ b/src/lib/Bcfg2/Server/Plugins/Vars.py
@@ -1,4 +1,4 @@
-""" Support for client ACLs based on IP address and client metadata """
+""" Support for metadata.Vars that can contain arbitrary strings for faster generation of templates """
 
 import copy
 import os

--- a/src/lib/Bcfg2/Server/Plugins/Vars.py
+++ b/src/lib/Bcfg2/Server/Plugins/Vars.py
@@ -1,0 +1,88 @@
+""" Support for client ACLs based on IP address and client metadata """
+
+import os
+import sys
+import Bcfg2.Server.Plugin
+import lxml
+import copy
+from Bcfg2.Server.Plugin import PluginExecutionError
+from Bcfg2.Server.Cache import Cache
+
+
+class VarsFile(Bcfg2.Server.Plugin.StructFile):
+    """ representation of Vars vars.xml """
+    def __init__(self, name, core, should_monitor=False):
+        """
+        :param name: The filename of this vars file.
+        :type name: string
+        :param core: The Bcfg2.Server.Core initializing the Vars plugin
+        :type core: Bcfg2.Server.Core
+        """
+        Bcfg2.Server.Plugin.StructFile.__init__(self, name,
+                                                should_monitor=should_monitor)
+        self.name = name
+        self.core = core
+        self.cache = Cache("Vars")
+
+    def Index(self):
+        Bcfg2.Server.Plugin.StructFile.Index(self)
+        self.cache.clear()
+
+    def get_vars(self, metadata):
+        if metadata.hostname in self.cache:
+            self.debug_log("Vars: Found cached vars for %s." % metadata.hostname)
+            return copy.copy(self.cache[metadata.hostname])
+        rv = dict()
+        for el in self.Match(metadata):
+            # only evaluate var tags, this is extensible in the future
+            if el.tag == "var":
+                self.debug_log(el)
+                if 'name' not in el.attrib:
+                    # if we have a correct schema, this should not happen
+                    raise Bcfg2.Server.Plugin.PluginExecutionError(
+                        "Vars: Invalid structure of vars.xml. Missing name attribute for variable.")
+                rv[el.get('name')] = el.text
+        self.cache[metadata.hostname] = copy.copy(rv)
+        return rv
+
+    def validate_data(self):
+        """ ensure that the data in this object validates against the
+        XML schema for the vars file (if a schema exists) """
+        schemafile = self.name.replace(".xml", ".xsd")
+        if os.path.exists(schemafile):
+            try:
+                schema = lxml.etree.XMLSchema(file=schemafile)
+            except lxml.etree.XMLSchemaParseError:
+                err = sys.exc_info()[1]
+                raise PluginExecutionError("Failed to process schema for %s: "
+                                           "%s" % (self.name, err))
+        else:
+            # no schema exists
+            return True
+
+        if not schema.validate(self.xdata):
+            raise PluginExecutionError("Data for %s fails to validate; run "
+                                       "bcfg2-lint for more details" %
+                                       self.name)
+
+class Vars(Bcfg2.Server.Plugin.Plugin,
+          Bcfg2.Server.Plugin.Connector):
+    """ add additional info to the metadata object based on entries in the vars.xml """
+
+    def __init__(self, core):
+        Bcfg2.Server.Plugin.Plugin.__init__(self, core)
+        Bcfg2.Server.Plugin.Connector.__init__(self)
+        self.vars_file = VarsFile(os.path.join(self.data, 'vars.xml'),
+                                  core,
+                                  should_monitor=True)
+
+    def get_additional_data(self, metadata):
+        """ """
+        self.debug_log("Vars: Getting vars for %s" % metadata.hostname)
+        return self.vars_file.get_vars(metadata)
+
+    def set_debug(self, debug):
+        rv = Bcfg2.Server.Plugin.Plugin.set_debug(self, debug)
+        self.vars_file.set_debug(debug)
+        return rv
+    set_debug.__doc__ = Bcfg2.Server.Plugin.Plugin.set_debug.__doc__


### PR DESCRIPTION
We needed a plugin that solves the problem of adding additional metadata that cannot be represented as a group:

For example:
```
<Group name="balanced">
   <Client name="foo.example.org">
        <var name="private_ip">10.0.1.3</var>
   </Client>
   ...
</Group>
```

This can now be accessed everywhere where a metadata object is present especially when generating configurations for monitoring systems like nagios / icinga.

We thought about mapping this to Properties, but we didn't want to reevaluate the properties everytime a client checks in, as we have an instance with 300+ clients.

Maybe you find this useful.

