### PR TITLE
Set default SSL protocol version to xmlrpc/ssl

### DIFF
--- a/src/lib/Bcfg2/Server/SSLServer.py
+++ b/src/lib/Bcfg2/Server/SSLServer.py
@@ -335,7 +335,7 @@ class XMLRPCServer(SocketServer.ThreadingMixIn, SSLServer,
     """ Component XMLRPCServer. """
 
     def __init__(self, listen_all, server_address, RequestHandlerClass=None,
-                 keyfile=None, certfile=None, ca=None, protocol='xmlrpc/tlsv1',
+                 keyfile=None, certfile=None, ca=None, protocol='xmlrpc/ssl',
                  timeout=10, logRequests=False,
                  register=True, allow_none=True, encoding=None):
         """


### PR DESCRIPTION
This is the secure choice with modern distributions. xmlrpc/tls1 limits the communication to TLSv1, while xmlrpc/ssl uses ssl.PROTOCOL_SSLv23. This protocol flag indicates that SSLv2 and SSLv3 could be used, but they are usually disabled in current versions of OpenSSL and allow clients to use the highest supported TLS version.

The best way would be to disable SSLv2 / SSLv3 contexts for the socket entirely (which is done by default in python 3)

See:
https://docs.python.org/2/library/ssl.html#socket-creation

The protocol name ssl.PROTOCOL_SSLv23 is deprecated starting with python 3.6 and is renamed to ssl.PROTOCOL_TLS.
