### PR TITLE
Fix testsuite

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -344,10 +344,6 @@ def check_object_path(key, url, path):
 
 intersphinx_mapping = {}
 intersphinx_mapping.update(\
-    check_object_path('mock',
-                      'http://www.voidspace.org.uk/python/mock',
-                      '/usr/share/doc/python-mock-doc/html/objects.inv'))
-intersphinx_mapping.update(\
     check_object_path('cherrypy',
                       'http://docs.cherrypy.org/stable',
                       'intersphinx/cherrypy/objects.inv'))

--- a/testsuite/install.sh
+++ b/testsuite/install.sh
@@ -27,8 +27,7 @@ else
     fi
 
     if [[ "$WITH_OPTIONAL_DEPS" == "yes" ]]; then
-        pip_wheel PyYAML pyinotify boto pylibacl Jinja2 \
-            cherrypy nose-show-skipped
+        pip_wheel pyinotify boto pylibacl Jinja2 cherrypy nose-show-skipped
 
         if [[ $PYVER == "2.6" ]]; then
             pip install \
@@ -36,13 +35,14 @@ else
                 --global-option='--include-dirs=/usr/include/x86_64-linux-gnu' \
                 m2crypto
 
-            pip_wheel 'django<1.7' 'South<0.8' 'mercurial<4.3' cheetah guppy 'pycparser<2.19' python-augeas
+            pip_wheel 'django<1.7' 'South<0.8' 'mercurial<4.3' cheetah guppy \
+                'pycparser<2.19' python-augeas 'PyYAML<5.1'
         else
             if [[ $PYVER == "2.7" ]]; then
                 pip_wheel m2crypto guppy
             fi
 
-            pip_wheel django mercurial cheetah3 python-augeas
+            pip_wheel django mercurial cheetah3 python-augeas PyYAML
         fi
     fi
 fi

--- a/testsuite/install.sh
+++ b/testsuite/install.sh
@@ -27,7 +27,8 @@ else
     fi
 
     if [[ "$WITH_OPTIONAL_DEPS" == "yes" ]]; then
-        pip_wheel pyinotify boto pylibacl Jinja2 cherrypy nose-show-skipped
+        pip_wheel pyinotify boto pylibacl Jinja2 cherrypy nose-show-skipped \
+            google_compute_engine
 
         if [[ $PYVER == "2.6" ]]; then
             pip install \

--- a/testsuite/requirements-26.txt
+++ b/testsuite/requirements-26.txt
@@ -1,4 +1,4 @@
-lxml
+lxml<4.3.0
 python-daemon<2.0.0
 argparse
 genshi


### PR DESCRIPTION
This will fix the testsuite:

* Python 2.6 requires an older version of lxml and PyYAML
* python-mock documentation was removed from voidspace.org.uk
* boto requires google_compute_engine (at least in the python2.6 environment of travis-ci)
