### PR TITLE
Reporting: Fix add_url_filter fallback

### DIFF
--- a/src/lib/Bcfg2/Reporting/templatetags/bcfg2_tags.py
+++ b/src/lib/Bcfg2/Reporting/templatetags/bcfg2_tags.py
@@ -11,6 +11,7 @@ from django.utils.safestring import mark_safe
 from datetime import datetime, timedelta
 from Bcfg2.Reporting.utils import filter_list
 from Bcfg2.Reporting.models import Group
+from Bcfg2.Reporting.views import render_history_view
 
 register = template.Library()
 
@@ -213,7 +214,7 @@ class AddUrlFilter(template.Node):
     def __init__(self, filter_name, filter_value):
         self.filter_name = filter_name
         self.filter_value = filter_value
-        self.fallback_view = 'Bcfg2.Reporting.views.render_history_view'
+        self.fallback_view = render_history_view
 
     def render(self, context):
         link = '#'


### PR DESCRIPTION
django-1.8 deprecated referencing views as strings in the url(), so we
need to import the fallback view and referencing the view function
directly.