### PR TITLE
Do not encode py3 strings to utf-8 again.

### DIFF
--- a/src/lib/Bcfg2/Server/Plugins/Probes.py
+++ b/src/lib/Bcfg2/Server/Plugins/Probes.py
@@ -307,7 +307,8 @@ class ProbeData(str):  # pylint: disable=E0012,R0924
     .json, and .yaml properties to provide convenient ways to use
     ProbeData objects as XML, JSON, or YAML data """
     def __new__(cls, data):
-        if isinstance(data, unicode):
+        # prevent double encoding utf-8 in python3
+        if isinstance(data, unicode) and not isinstance(data, str):
             return str.__new__(cls, data.encode('utf-8'))
         else:
             return str.__new__(cls, data)


### PR DESCRIPTION
 Do not encode py3 strings to utf-8 again. Compat.unicode matches strings and unicode in py3.