### PR TITLE
testsuite: Fix pip index-url for ancient python

### DIFF
--- a/testsuite/install.sh
+++ b/testsuite/install.sh
@@ -5,7 +5,7 @@ PYVER=$(python -c 'import sys;print(".".join(str(v) for v in sys.version_info[0:
 SITE_PACKAGES=$(python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')
 
 if [[ ${PYVER:0:1} == "2" && $PYVER != "2.7" && $PYVER != "2.6" ]]; then
-    pip install --index-url=https://pypi.python.org/simple -r testsuite/requirements-legacy.txt
+    pip install --index-url=https://pypi.org/simple -r testsuite/requirements-legacy.txt
 else
     pip install --upgrade pip
 


### PR DESCRIPTION
This should fix the recent travis failure. 