### PR TITLE
Fix caching problem in probegroups

### DIFF
--- a/src/lib/Bcfg2/Server/Plugins/Probes.py
+++ b/src/lib/Bcfg2/Server/Plugins/Probes.py
@@ -141,8 +141,8 @@ class DBProbeStore(ProbeStore, Bcfg2.Server.Plugin.DatabaseBacked):
 
     @Bcfg2.Server.Plugin.DatabaseBacked.get_db_lock
     def set_groups(self, hostname, groups):
-        Bcfg2.Server.Cache.expire("Probes", "probegroups", hostname)
         olddata = self._groupcache.get(hostname, [])
+        Bcfg2.Server.Cache.expire("Probes", "probegroups", hostname)
         self._groupcache[hostname] = groups
         for group in groups:
             try:


### PR DESCRIPTION
There has been a long going issue, that if aggressive caching is used, the Cache is always expired if a client checks in.
This is due to a bug, that clears the cache before retrieving the old information, which leads to the new groups assigned by a probe to be always new, as olddata is always [].

This should fix performance for servers that are utilizing the "aggressive" caching mode.