### PR TITLE
Fix default timezone in debian buster

### DIFF
--- a/src/lib/Bcfg2/DBSettings.py
+++ b/src/lib/Bcfg2/DBSettings.py
@@ -23,7 +23,7 @@ except ImportError:
 
 # pylint: disable=C0103
 settings = dict(
-    TIME_ZONE=None,
+    TIME_ZONE='UTC',
     TEMPLATE_DEBUG=False,
     DEBUG=False,
     ALLOWED_HOSTS=['*'],


### PR DESCRIPTION
bcfg2-web will fail without setting a valid time zone in newer django versions. This fix initializes the time zone as utc instead of None, to fix most setups without directly breaking functionality. This can be fixed without changing the code by adding this to the config file.
```
# /etc/bcfg2-web.conf
[reporting]
TIME_ZONE = <valid_tz>
```

using UTC is recommended by django: https://riptutorial.com/django/example/3107/setting-the-timezone