### PR TITLE
Utils: Encode str to bytes in Executor.run

### DIFF
--- a/src/lib/Bcfg2/Utils.py
+++ b/src/lib/Bcfg2/Utils.py
@@ -241,6 +241,11 @@ class Executor(object):
             if inputdata:
                 for line in inputdata.splitlines():
                     self.logger.debug('> %s' % line)
+
+                # py3k fixes
+                if sys.hexversion >= 0x03000000:
+                    inputdata = inputdata.encode('utf-8')
+
             (stdout, stderr) = proc.communicate(input=inputdata)
 
             # py3k fixes


### PR DESCRIPTION
This is the input complement to the output decoding added in [2cb245f4eb](https://github.com/Bcfg2/bcfg2/commit/2cb245f4ebf5dbd37f11f02a7d1598b050799515#diff-db979a9de87467e93e43338f78bcbd269ce62a34518cf57e5688aa43a244345cR244-R248).

In [`Admin.py`](https://github.com/Bcfg2/bcfg2/blob/8605cd3d0cb4d549cb8b43de945d447f6d82892a/src/lib/Bcfg2/Server/Admin.py#L689), some output is passed back in as input, which causes a crash in Python 3 without this change.

Somewhat related (and possibly controversial) thoughts: The codebase is getting rather hairy due to having support for both modern and ancient versions of Python. How likely is it that a distribution will include a 2021+ version of bcfg2, but not have a version of Python 3 from at least 2017? Would it be reasonable to drop the 1.4 release entirely, and instead focus on a hypothetical 2.0 with support only for Python 3.6+, or something along those lines? I understand the desire to keep compatibility with existing software, and the amount of work put into bcfg2 towards this goal is commendable. It would certainly be a shame to discard it all, but does it still provide enough benefit to justify the added maintenance burden?